### PR TITLE
Fixed skirmishes without a quest contract

### DIFF
--- a/apps/quest/handlers/events/quest_contract.py
+++ b/apps/quest/handlers/events/quest_contract.py
@@ -7,7 +7,12 @@ from apps.skirmish.messages.events import skirmish
 
 
 @message_registry.register_event(event=skirmish.SkirmishCreated)
-def handle_link_quest_contract_to_its_skirmish(*, context: skirmish.SkirmishCreated) -> Command:
+def handle_link_quest_contract_to_its_skirmish(*, context: skirmish.SkirmishCreated) -> Command | None:
+    # Not every skirmish comes from a quest: attacking a rival faction creates one without a
+    # contract, and there is nothing to link then
+    if context.quest_contract is None:
+        return None
+
     return AssignSkirmishToQuestContract(quest_contract=context.quest_contract, skirmish=context.skirmish)
 
 

--- a/apps/quest/tests/handlers/commands/test_quest_contract.py
+++ b/apps/quest/tests/handlers/commands/test_quest_contract.py
@@ -1,9 +1,31 @@
 import pytest
 
-from apps.quest.handlers.commands.quest_contract import handle_remove_quest_contract_as_active_quest
-from apps.quest.messages.commands.quest_contract import RemoveQuestContractAsActiveQuest
-from apps.quest.messages.events.quest_contract import QuestContractAsActiveQuestRemoved
+from apps.quest.handlers.commands.quest_contract import (
+    handle_assign_skirmish_to_quest_contract,
+    handle_remove_quest_contract_as_active_quest,
+)
+from apps.quest.messages.commands.quest_contract import AssignSkirmishToQuestContract, RemoveQuestContractAsActiveQuest
+from apps.quest.messages.events.quest_contract import QuestContractAsActiveQuestRemoved, SkirmishToQuestContractAssigned
 from apps.quest.tests.factories.quest_contract import QuestContractFactory
+from apps.skirmish.tests.factories.skirmish import SkirmishFactory
+
+
+@pytest.mark.django_db
+def test_handle_assign_skirmish_to_quest_contract_stores_the_link():
+    """
+    This handler is the only writer of the link, so nothing but a flow test on the quest view would
+    notice it regressing - and that one would blame the view rather than the handler.
+    """
+    skirmish = SkirmishFactory()
+    quest_contract = QuestContractFactory(faction=skirmish.player_faction)
+
+    result = handle_assign_skirmish_to_quest_contract(
+        context=AssignSkirmishToQuestContract(quest_contract=quest_contract, skirmish=skirmish)
+    )
+
+    assert result == SkirmishToQuestContractAssigned(quest_contract=quest_contract)
+    quest_contract.refresh_from_db()
+    assert quest_contract.skirmish == skirmish
 
 
 @pytest.mark.django_db

--- a/apps/quest/tests/handlers/events/test_quest_contract.py
+++ b/apps/quest/tests/handlers/events/test_quest_contract.py
@@ -1,10 +1,34 @@
 import pytest
 
-from apps.quest.handlers.events.quest_contract import handle_finish_quest_contract
-from apps.quest.messages.commands.quest_contract import RemoveQuestContractAsActiveQuest
+from apps.quest.handlers.events.quest_contract import (
+    handle_finish_quest_contract,
+    handle_link_quest_contract_to_its_skirmish,
+)
+from apps.quest.messages.commands.quest_contract import AssignSkirmishToQuestContract, RemoveQuestContractAsActiveQuest
 from apps.quest.tests.factories.quest_contract import QuestContractFactory
-from apps.skirmish.messages.events.skirmish import SkirmishFinished
+from apps.skirmish.messages.events.skirmish import SkirmishCreated, SkirmishFinished
 from apps.skirmish.tests.factories.skirmish import SkirmishFactory
+
+
+@pytest.mark.django_db
+def test_handle_link_quest_contract_to_its_skirmish_assigns_the_contract():
+    skirmish = SkirmishFactory()
+    quest_contract = QuestContractFactory(faction=skirmish.player_faction)
+
+    result = handle_link_quest_contract_to_its_skirmish(
+        context=SkirmishCreated(skirmish=skirmish, quest_contract=quest_contract)
+    )
+
+    assert result == AssignSkirmishToQuestContract(quest_contract=quest_contract, skirmish=skirmish)
+
+
+@pytest.mark.django_db
+def test_handle_link_quest_contract_to_its_skirmish_stays_silent_without_a_contract():
+    skirmish = SkirmishFactory()
+
+    result = handle_link_quest_contract_to_its_skirmish(context=SkirmishCreated(skirmish=skirmish, quest_contract=None))
+
+    assert result is None
 
 
 @pytest.mark.django_db

--- a/apps/skirmish/handlers/commands/skirmish.py
+++ b/apps/skirmish/handlers/commands/skirmish.py
@@ -42,10 +42,8 @@ def handle_create_skirmish(*, context: skirmish.CreateSkirmish) -> list[Event] |
     )
     new_skirmish = skirmish_generator.process()
 
-    if context.quest_contract:
-        context.quest_contract.skirmish = new_skirmish
-        context.quest_contract.save()
-
+    # Linking the contract to the skirmish is the quest app's reaction to SkirmishCreated, see
+    # handle_link_quest_contract_to_its_skirmish - writing it here as well meant doing it twice
     return SkirmishCreated(
         skirmish=new_skirmish,
         quest_contract=context.quest_contract,

--- a/apps/skirmish/tests/handlers/commands/test_skirmish.py
+++ b/apps/skirmish/tests/handlers/commands/test_skirmish.py
@@ -78,7 +78,7 @@ def test_handle_create_skirmish_generates_opponents_when_none_are_given():
 
 
 @pytest.mark.django_db
-def test_handle_create_skirmish_links_the_quest_contract_to_the_new_skirmish():
+def test_handle_create_skirmish_passes_the_quest_contract_on():
     quest_contract = QuestContractFactory()
     player_warrior = WarriorFactory(faction=quest_contract.faction)
     enemy_warrior = WarriorFactory(faction=quest_contract.quest.target_faction)
@@ -95,8 +95,6 @@ def test_handle_create_skirmish_links_the_quest_contract_to_the_new_skirmish():
     )
 
     assert result.quest_contract == quest_contract
-    quest_contract.refresh_from_db()
-    assert quest_contract.skirmish == result.skirmish
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Creating a skirmish without a quest contract raised an AttributeError and rolled the whole handle_message transaction back: handle_link_quest_contract_to_its_skirmish emitted AssignSkirmishToQuestContract unconditionally, whose handler dereferences the contract.

The same assignment also happened inline in handle_create_skirmish. Removed there and kept on the bus, since linking the contract is the quest app's reaction to a skirmish event.