### PR TITLE
Let rival factions recover between months

### DIFF
--- a/apps/faction/handlers/events/faction.py
+++ b/apps/faction/handlers/events/faction.py
@@ -10,7 +10,7 @@ from apps.faction.messages.commands.faction import (
     ReplenishFyrdReserve,
 )
 from apps.faction.messages.events.faction import FactionWarriorsWithReducedMoraleDetermined
-from apps.month.messages.events.month import MonthPrepared, RivalFactionMonthPrepared
+from apps.month.messages.events.month import FactionMonthPrepared, PlayerMonthPrepared
 from apps.savegame.messages.events.savegame import NewSavegameCreated
 from apps.warrior.messages.commands.warrior import ReplenishWarriorMorale
 
@@ -42,34 +42,28 @@ def handle_warriors_with_reduced_morale_determined(
     return event_list
 
 
-@message_registry.register_event(event=MonthPrepared)
-def handle_replenish_fyrd_reserve_for_new_month(*, context: MonthPrepared) -> list[Command]:
+@message_registry.register_event(event=PlayerMonthPrepared)
+def handle_replenish_fyrd_reserve_for_new_month(*, context: PlayerMonthPrepared) -> list[Command]:
     return [ReplenishFyrdReserve(faction=context.faction, month=context.current_month)]
 
 
-@message_registry.register_event(event=MonthPrepared)
-def handle_pay_monthly_warrior_salaries_for_new_month(*, context: MonthPrepared) -> Command:
+@message_registry.register_event(event=PlayerMonthPrepared)
+def handle_pay_monthly_warrior_salaries_for_new_month(*, context: PlayerMonthPrepared) -> Command:
     return PayMonthlyWarriorSalaries(faction=context.faction, month=context.current_month)
 
 
-@message_registry.register_event(event=MonthPrepared)
-def handle_earn_money_from_buildings_for_new_month(*, context: MonthPrepared) -> Command:
+@message_registry.register_event(event=PlayerMonthPrepared)
+def handle_earn_money_from_buildings_for_new_month(*, context: PlayerMonthPrepared) -> Command:
     return EarnMoneyFromBuildings(faction=context.faction, month=context.current_month)
 
 
-# Rivals recover between months as well, otherwise a faction that survived one battle stays crippled
-# for the rest of the game and can never be knocked out
-@message_registry.register_event(event=RivalFactionMonthPrepared)
-@message_registry.register_event(event=MonthPrepared)
-def handle_determine_warriors_with_reduced_morale_for_new_month(
-    *, context: MonthPrepared | RivalFactionMonthPrepared
-) -> list[Command]:
+# Every faction recovers, not just the player's: otherwise one that survived a battle stays crippled
+# for the rest of the game and can never be knocked out again
+@message_registry.register_event(event=FactionMonthPrepared)
+def handle_determine_warriors_with_reduced_morale_for_new_month(*, context: FactionMonthPrepared) -> list[Command]:
     return [DetermineWarriorsWithReducedMorale(faction=context.faction, month=context.current_month)]
 
 
-@message_registry.register_event(event=RivalFactionMonthPrepared)
-@message_registry.register_event(event=MonthPrepared)
-def handle_determine_injured_warriors_for_new_month(
-    *, context: MonthPrepared | RivalFactionMonthPrepared
-) -> list[Command]:
+@message_registry.register_event(event=FactionMonthPrepared)
+def handle_determine_injured_warriors_for_new_month(*, context: FactionMonthPrepared) -> list[Command]:
     return [DetermineInjuredWarriors(faction=context.faction, month=context.current_month)]

--- a/apps/faction/handlers/events/faction.py
+++ b/apps/faction/handlers/events/faction.py
@@ -10,7 +10,7 @@ from apps.faction.messages.commands.faction import (
     ReplenishFyrdReserve,
 )
 from apps.faction.messages.events.faction import FactionWarriorsWithReducedMoraleDetermined
-from apps.month.messages.events.month import MonthPrepared
+from apps.month.messages.events.month import MonthPrepared, RivalFactionMonthPrepared
 from apps.savegame.messages.events.savegame import NewSavegameCreated
 from apps.warrior.messages.commands.warrior import ReplenishWarriorMorale
 
@@ -57,11 +57,19 @@ def handle_earn_money_from_buildings_for_new_month(*, context: MonthPrepared) ->
     return EarnMoneyFromBuildings(faction=context.faction, month=context.current_month)
 
 
+# Rivals recover between months as well, otherwise a faction that survived one battle stays crippled
+# for the rest of the game and can never be knocked out
+@message_registry.register_event(event=RivalFactionMonthPrepared)
 @message_registry.register_event(event=MonthPrepared)
-def handle_determine_warriors_with_reduced_morale_for_new_month(*, context: MonthPrepared) -> list[Command]:
+def handle_determine_warriors_with_reduced_morale_for_new_month(
+    *, context: MonthPrepared | RivalFactionMonthPrepared
+) -> list[Command]:
     return [DetermineWarriorsWithReducedMorale(faction=context.faction, month=context.current_month)]
 
 
+@message_registry.register_event(event=RivalFactionMonthPrepared)
 @message_registry.register_event(event=MonthPrepared)
-def handle_determine_injured_warriors_for_new_month(*, context: MonthPrepared) -> list[Command]:
+def handle_determine_injured_warriors_for_new_month(
+    *, context: MonthPrepared | RivalFactionMonthPrepared
+) -> list[Command]:
     return [DetermineInjuredWarriors(faction=context.faction, month=context.current_month)]

--- a/apps/faction/handlers/events/item.py
+++ b/apps/faction/handlers/events/item.py
@@ -5,7 +5,7 @@ from apps.faction.messages.commands.faction import RestockTownShopItems
 from apps.faction.messages.commands.item import AddItemToTownShop, RemoveItemFromTownShop
 from apps.faction.messages.events.faction import NewFactionCreated
 from apps.item.messages.events import item
-from apps.month.messages.events.month import MonthPrepared
+from apps.month.messages.events.month import PlayerMonthPrepared
 
 
 @message_registry.register_event(event=item.ItemCreated)
@@ -27,6 +27,6 @@ def handle_remove_bought_item_from_shop(*, context: item.ItemBought) -> Command:
 
 
 @message_registry.register_event(event=NewFactionCreated)
-@message_registry.register_event(event=MonthPrepared)
-def handle_restock_items_in_shop_for_new_month(*, context: MonthPrepared | NewFactionCreated) -> Command:
+@message_registry.register_event(event=PlayerMonthPrepared)
+def handle_restock_items_in_shop_for_new_month(*, context: PlayerMonthPrepared | NewFactionCreated) -> Command:
     return RestockTownShopItems(faction=context.faction, month=context.current_month)

--- a/apps/faction/handlers/events/quest.py
+++ b/apps/faction/handlers/events/quest.py
@@ -3,10 +3,10 @@ from queuebie.messages import Command
 
 from apps.faction.messages.commands.quest import OfferNewQuestsOnBulletinBoard
 from apps.faction.messages.events.faction import NewFactionCreated
-from apps.month.messages.events.month import MonthPrepared
+from apps.month.messages.events.month import PlayerMonthPrepared
 
 
 @message_registry.register_event(event=NewFactionCreated)
-@message_registry.register_event(event=MonthPrepared)
-def handle_offer_new_quests_on_bulletin_board(*, context: MonthPrepared | NewFactionCreated) -> Command:
+@message_registry.register_event(event=PlayerMonthPrepared)
+def handle_offer_new_quests_on_bulletin_board(*, context: PlayerMonthPrepared | NewFactionCreated) -> Command:
     return OfferNewQuestsOnBulletinBoard(faction=context.faction, month=context.current_month)

--- a/apps/faction/handlers/events/warrior.py
+++ b/apps/faction/handlers/events/warrior.py
@@ -4,7 +4,7 @@ from queuebie.messages import Command
 from apps.faction.messages.commands.faction import AddWarriorToPub, SetNewLeaderWarrior
 from apps.faction.messages.commands.warrior import RestockTownMercenaries
 from apps.faction.messages.events.faction import NewFactionCreated
-from apps.month.messages.events.month import MonthPrepared
+from apps.month.messages.events.month import PlayerMonthPrepared
 from apps.warrior.messages.events.warrior import NewLeaderWarriorCreated, WarriorCreated
 
 
@@ -21,6 +21,6 @@ def handle_add_new_warrior_to_faction_pub(*, context: WarriorCreated) -> Command
 
 
 @message_registry.register_event(event=NewFactionCreated)
-@message_registry.register_event(event=MonthPrepared)
-def handle_restock_mercenaries_in_pub_for_new_month(*, context: MonthPrepared | NewFactionCreated) -> Command:
+@message_registry.register_event(event=PlayerMonthPrepared)
+def handle_restock_mercenaries_in_pub_for_new_month(*, context: PlayerMonthPrepared | NewFactionCreated) -> Command:
     return RestockTownMercenaries(faction=context.faction, month=context.current_month)

--- a/apps/faction/managers/faction.py
+++ b/apps/faction/managers/faction.py
@@ -9,6 +9,18 @@ class FactionQuerySet(models.QuerySet):
     def for_player_faction(self, *, faction_id: int):
         return self.filter(id=faction_id)
 
+    def rivals_of(self, *, savegame_id: int, player_faction_id: int | None):
+        """
+        Every faction of the savegame the player does not control.
+
+        A savegame without a player faction yet is a reachable state, and excluding "None" keeps
+        every row rather than dropping them - there is nobody to exclude at that point.
+
+        This is the one place deciding which rivals still take part in the game, so the "is this
+        faction defeated" filter belongs here once that flag exists.
+        """
+        return self.for_savegame(savegame_id=savegame_id).exclude(id=player_faction_id)
+
 
 class FactionManager(manager.Manager):
     def add_captive(self, *, faction, warrior):

--- a/apps/faction/managers/faction.py
+++ b/apps/faction/managers/faction.py
@@ -9,17 +9,14 @@ class FactionQuerySet(models.QuerySet):
     def for_player_faction(self, *, faction_id: int):
         return self.filter(id=faction_id)
 
-    def rivals_of(self, *, savegame_id: int, player_faction_id: int | None):
+    def still_in_play(self, *, savegame_id: int):
         """
-        Every faction of the savegame the player does not control.
+        Every faction of the savegame still taking part in the game, the player's included.
 
-        A savegame without a player faction yet is a reachable state, and excluding "None" keeps
-        every row rather than dropping them - there is nobody to exclude at that point.
-
-        This is the one place deciding which rivals still take part in the game, so the "is this
-        faction defeated" filter belongs here once that flag exists.
+        This is the one place deciding who is still in it, so the "is this faction defeated" filter
+        belongs here once that flag exists.
         """
-        return self.for_savegame(savegame_id=savegame_id).exclude(id=player_faction_id)
+        return self.for_savegame(savegame_id=savegame_id)
 
 
 class FactionManager(manager.Manager):

--- a/apps/faction/tests/handlers/events/test_faction.py
+++ b/apps/faction/tests/handlers/events/test_faction.py
@@ -1,12 +1,19 @@
 from apps.faction.handlers.events.faction import (
     handle_create_player_faction_for_new_savegame,
+    handle_determine_injured_warriors_for_new_month,
+    handle_determine_warriors_with_reduced_morale_for_new_month,
     handle_earn_money_from_buildings_for_new_month,
     handle_warriors_with_reduced_morale_determined,
 )
-from apps.faction.messages.commands.faction import CreateFactionsForNewSavegame, EarnMoneyFromBuildings
+from apps.faction.messages.commands.faction import (
+    CreateFactionsForNewSavegame,
+    DetermineInjuredWarriors,
+    DetermineWarriorsWithReducedMorale,
+    EarnMoneyFromBuildings,
+)
 from apps.faction.messages.events.faction import FactionWarriorsWithReducedMoraleDetermined
 from apps.faction.tests.factories.faction import FactionFactory
-from apps.month.messages.events.month import MonthPrepared
+from apps.month.messages.events.month import MonthPrepared, RivalFactionMonthPrepared
 from apps.savegame.messages.events.savegame import NewSavegameCreated
 from apps.savegame.tests.factories.savegame import SavegameFactory
 from apps.skirmish.tests.factories.warrior import WarriorFactory
@@ -62,3 +69,45 @@ def test_handle_earn_money_from_buildings_for_new_month_maps_to_command():
     result = handle_earn_money_from_buildings_for_new_month(context=context)
 
     assert result == EarnMoneyFromBuildings(faction=faction, month=7)
+
+
+def test_handle_determine_warriors_with_reduced_morale_for_new_month_for_the_player():
+    faction = FactionFactory.build()
+    context = MonthPrepared(
+        faction=faction, savegame=SavegameFactory.build(), training=TrainingFactory.build(), current_month=7
+    )
+
+    result = handle_determine_warriors_with_reduced_morale_for_new_month(context=context)
+
+    assert result == [DetermineWarriorsWithReducedMorale(faction=faction, month=7)]
+
+
+def test_handle_determine_warriors_with_reduced_morale_for_new_month_for_a_rival():
+    faction = FactionFactory.build()
+
+    result = handle_determine_warriors_with_reduced_morale_for_new_month(
+        context=RivalFactionMonthPrepared(faction=faction, current_month=7)
+    )
+
+    assert result == [DetermineWarriorsWithReducedMorale(faction=faction, month=7)]
+
+
+def test_handle_determine_injured_warriors_for_new_month_for_the_player():
+    faction = FactionFactory.build()
+    context = MonthPrepared(
+        faction=faction, savegame=SavegameFactory.build(), training=TrainingFactory.build(), current_month=7
+    )
+
+    result = handle_determine_injured_warriors_for_new_month(context=context)
+
+    assert result == [DetermineInjuredWarriors(faction=faction, month=7)]
+
+
+def test_handle_determine_injured_warriors_for_new_month_for_a_rival():
+    faction = FactionFactory.build()
+
+    result = handle_determine_injured_warriors_for_new_month(
+        context=RivalFactionMonthPrepared(faction=faction, current_month=7)
+    )
+
+    assert result == [DetermineInjuredWarriors(faction=faction, month=7)]

--- a/apps/faction/tests/handlers/events/test_faction.py
+++ b/apps/faction/tests/handlers/events/test_faction.py
@@ -13,7 +13,7 @@ from apps.faction.messages.commands.faction import (
 )
 from apps.faction.messages.events.faction import FactionWarriorsWithReducedMoraleDetermined
 from apps.faction.tests.factories.faction import FactionFactory
-from apps.month.messages.events.month import MonthPrepared, RivalFactionMonthPrepared
+from apps.month.messages.events.month import FactionMonthPrepared, PlayerMonthPrepared
 from apps.savegame.messages.events.savegame import NewSavegameCreated
 from apps.savegame.tests.factories.savegame import SavegameFactory
 from apps.skirmish.tests.factories.warrior import WarriorFactory
@@ -62,7 +62,7 @@ def test_handle_warriors_with_reduced_morale_determined_without_warriors():
 
 def test_handle_earn_money_from_buildings_for_new_month_maps_to_command():
     faction = FactionFactory.build()
-    context = MonthPrepared(
+    context = PlayerMonthPrepared(
         faction=faction, savegame=SavegameFactory.build(), training=TrainingFactory.build(), current_month=7
     )
 
@@ -71,43 +71,21 @@ def test_handle_earn_money_from_buildings_for_new_month_maps_to_command():
     assert result == EarnMoneyFromBuildings(faction=faction, month=7)
 
 
-def test_handle_determine_warriors_with_reduced_morale_for_new_month_for_the_player():
-    faction = FactionFactory.build()
-    context = MonthPrepared(
-        faction=faction, savegame=SavegameFactory.build(), training=TrainingFactory.build(), current_month=7
-    )
-
-    result = handle_determine_warriors_with_reduced_morale_for_new_month(context=context)
-
-    assert result == [DetermineWarriorsWithReducedMorale(faction=faction, month=7)]
-
-
-def test_handle_determine_warriors_with_reduced_morale_for_new_month_for_a_rival():
+def test_handle_determine_warriors_with_reduced_morale_for_new_month_maps_to_command():
     faction = FactionFactory.build()
 
     result = handle_determine_warriors_with_reduced_morale_for_new_month(
-        context=RivalFactionMonthPrepared(faction=faction, current_month=7)
+        context=FactionMonthPrepared(faction=faction, current_month=7)
     )
 
     assert result == [DetermineWarriorsWithReducedMorale(faction=faction, month=7)]
 
 
-def test_handle_determine_injured_warriors_for_new_month_for_the_player():
-    faction = FactionFactory.build()
-    context = MonthPrepared(
-        faction=faction, savegame=SavegameFactory.build(), training=TrainingFactory.build(), current_month=7
-    )
-
-    result = handle_determine_injured_warriors_for_new_month(context=context)
-
-    assert result == [DetermineInjuredWarriors(faction=faction, month=7)]
-
-
-def test_handle_determine_injured_warriors_for_new_month_for_a_rival():
+def test_handle_determine_injured_warriors_for_new_month_maps_to_command():
     faction = FactionFactory.build()
 
     result = handle_determine_injured_warriors_for_new_month(
-        context=RivalFactionMonthPrepared(faction=faction, current_month=7)
+        context=FactionMonthPrepared(faction=faction, current_month=7)
     )
 
     assert result == [DetermineInjuredWarriors(faction=faction, month=7)]

--- a/apps/faction/tests/handlers/events/test_quest.py
+++ b/apps/faction/tests/handlers/events/test_quest.py
@@ -1,7 +1,7 @@
 from apps.faction.handlers.events.quest import handle_offer_new_quests_on_bulletin_board
 from apps.faction.messages.commands.quest import OfferNewQuestsOnBulletinBoard
 from apps.faction.tests.factories.faction import FactionFactory
-from apps.month.messages.events.month import MonthPrepared
+from apps.month.messages.events.month import PlayerMonthPrepared
 from apps.savegame.tests.factories.savegame import SavegameFactory
 from apps.training.tests.factories.training import TrainingFactory
 
@@ -12,7 +12,7 @@ def test_handle_offer_new_quests_on_bulletin_board_maps_to_command():
     database is needed.
     """
     faction = FactionFactory.build()
-    context = MonthPrepared(
+    context = PlayerMonthPrepared(
         faction=faction, savegame=SavegameFactory.build(), training=TrainingFactory.build(), current_month=7
     )
 

--- a/apps/faction/tests/managers/test_faction.py
+++ b/apps/faction/tests/managers/test_faction.py
@@ -17,25 +17,12 @@ def test_add_captive_arrests_the_warrior():
 
 
 @pytest.mark.django_db
-def test_rivals_of_leaves_out_the_player_faction():
-    savegame = SavegameFactory()
-    player_faction = FactionFactory(savegame=savegame)
-    rival_faction = FactionFactory(savegame=savegame)
-
-    result = Faction.objects.rivals_of(savegame_id=savegame.id, player_faction_id=player_faction.id)
-
-    assert list(result) == [rival_faction]
-
-
-@pytest.mark.django_db
-def test_rivals_of_without_a_player_faction():
-    """
-    A savegame gets its row before its factions exist, so there is nobody to leave out yet.
-    """
+def test_still_in_play_returns_the_factions_of_the_savegame():
     savegame = SavegameFactory()
     faction = FactionFactory(savegame=savegame)
+    FactionFactory()
 
-    result = Faction.objects.rivals_of(savegame_id=savegame.id, player_faction_id=None)
+    result = Faction.objects.still_in_play(savegame_id=savegame.id)
 
     assert list(result) == [faction]
 

--- a/apps/faction/tests/managers/test_faction.py
+++ b/apps/faction/tests/managers/test_faction.py
@@ -2,6 +2,7 @@ import pytest
 
 from apps.faction.models.faction import Faction
 from apps.faction.tests.factories.faction import FactionFactory
+from apps.savegame.tests.factories.savegame import SavegameFactory
 from apps.skirmish.tests.factories.warrior import WarriorFactory
 
 
@@ -13,6 +14,30 @@ def test_add_captive_arrests_the_warrior():
     Faction.objects.add_captive(faction=faction, warrior=warrior)
 
     assert list(faction.captured_warriors.all()) == [warrior]
+
+
+@pytest.mark.django_db
+def test_rivals_of_leaves_out_the_player_faction():
+    savegame = SavegameFactory()
+    player_faction = FactionFactory(savegame=savegame)
+    rival_faction = FactionFactory(savegame=savegame)
+
+    result = Faction.objects.rivals_of(savegame_id=savegame.id, player_faction_id=player_faction.id)
+
+    assert list(result) == [rival_faction]
+
+
+@pytest.mark.django_db
+def test_rivals_of_without_a_player_faction():
+    """
+    A savegame gets its row before its factions exist, so there is nobody to leave out yet.
+    """
+    savegame = SavegameFactory()
+    faction = FactionFactory(savegame=savegame)
+
+    result = Faction.objects.rivals_of(savegame_id=savegame.id, player_faction_id=None)
+
+    assert list(result) == [faction]
 
 
 @pytest.mark.django_db

--- a/apps/month/handlers/commands/month.py
+++ b/apps/month/handlers/commands/month.py
@@ -1,33 +1,52 @@
 from queuebie import message_registry
 from queuebie.messages import Event
 
+from apps.faction.models.faction import Faction
 from apps.month.messages.commands.month import ClearPlayerMonthLog, CreatePlayerMonthLog, PrepareMonth
-from apps.month.messages.events.month import MonthPrepared, PlayerMonthLogCleared, PlayerMonthLogCreated
+from apps.month.messages.events.month import (
+    MonthPrepared,
+    PlayerMonthLogCleared,
+    PlayerMonthLogCreated,
+    RivalFactionMonthPrepared,
+)
 from apps.month.models import PlayerMonthLog
 from apps.training.models.training import Training
 
 
 @message_registry.register_command(command=PrepareMonth)
-def handle_prepare_month(*, context: PrepareMonth) -> Event:
+def handle_prepare_month(*, context: PrepareMonth) -> list[Event]:
     # Increment current month
     current_month = context.savegame.current_month + 1
     context.savegame.current_month = current_month
     context.savegame.save()
 
-    return MonthPrepared(
-        faction=context.savegame.player_faction,
-        savegame=context.savegame,
-        # TODO: store this months training somewhere -> in savegame?
-        # Scoped to the player's own faction: every faction of the savegame owns a training row, so
-        # scoping to the savegame would still train the player's warriors by whichever row happens
-        # to come first. Stays None when there is no row - the consumer handles that.
-        training=(
-            Training.objects.for_player_faction(faction_id=context.savegame.player_faction_id).first()
-            if context.savegame.player_faction_id
-            else None
-        ),
-        current_month=current_month,
+    # One event per rival next to the player's. Rivals only recover between months today; giving
+    # them income or a restocked shop is a matter of stacking those handlers onto the event too,
+    # see RivalFactionMonthPrepared
+    rival_faction_list = Faction.objects.rivals_of(
+        savegame_id=context.savegame.id, player_faction_id=context.savegame.player_faction_id
     )
+
+    return [
+        MonthPrepared(
+            faction=context.savegame.player_faction,
+            savegame=context.savegame,
+            # TODO: store this months training somewhere -> in savegame?
+            # Scoped to the player's own faction: every faction of the savegame owns a training row,
+            # so scoping to the savegame would still train the player's warriors by whichever row
+            # happens to come first. Stays None when there is no row - the consumer handles that.
+            training=(
+                Training.objects.for_player_faction(faction_id=context.savegame.player_faction_id).first()
+                if context.savegame.player_faction_id
+                else None
+            ),
+            current_month=current_month,
+        ),
+        *[
+            RivalFactionMonthPrepared(faction=rival_faction, current_month=current_month)
+            for rival_faction in rival_faction_list
+        ],
+    ]
 
 
 @message_registry.register_command(command=CreatePlayerMonthLog)

--- a/apps/month/handlers/commands/month.py
+++ b/apps/month/handlers/commands/month.py
@@ -4,10 +4,10 @@ from queuebie.messages import Event
 from apps.faction.models.faction import Faction
 from apps.month.messages.commands.month import ClearPlayerMonthLog, CreatePlayerMonthLog, PrepareMonth
 from apps.month.messages.events.month import (
-    MonthPrepared,
+    FactionMonthPrepared,
     PlayerMonthLogCleared,
     PlayerMonthLogCreated,
-    RivalFactionMonthPrepared,
+    PlayerMonthPrepared,
 )
 from apps.month.models import PlayerMonthLog
 from apps.training.models.training import Training
@@ -20,15 +20,12 @@ def handle_prepare_month(*, context: PrepareMonth) -> list[Event]:
     context.savegame.current_month = current_month
     context.savegame.save()
 
-    # One event per rival next to the player's. Rivals only recover between months today; giving
-    # them income or a restocked shop is a matter of stacking those handlers onto the event too,
-    # see RivalFactionMonthPrepared
-    rival_faction_list = Faction.objects.rivals_of(
-        savegame_id=context.savegame.id, player_faction_id=context.savegame.player_faction_id
-    )
+    # Every faction of the savegame gets its month, the player's included - what each of them
+    # actually does with it is decided by which handlers subscribe, not by who they are
+    faction_list = Faction.objects.still_in_play(savegame_id=context.savegame.id)
 
     return [
-        MonthPrepared(
+        PlayerMonthPrepared(
             faction=context.savegame.player_faction,
             savegame=context.savegame,
             # TODO: store this months training somewhere -> in savegame?
@@ -42,10 +39,7 @@ def handle_prepare_month(*, context: PrepareMonth) -> list[Event]:
             ),
             current_month=current_month,
         ),
-        *[
-            RivalFactionMonthPrepared(faction=rival_faction, current_month=current_month)
-            for rival_faction in rival_faction_list
-        ],
+        *[FactionMonthPrepared(faction=faction, current_month=current_month) for faction in faction_list],
     ]
 
 

--- a/apps/month/handlers/events/player_month_log.py
+++ b/apps/month/handlers/events/player_month_log.py
@@ -2,9 +2,9 @@ from queuebie import message_registry
 from queuebie.messages import Command
 
 from apps.month.messages.commands.month import ClearPlayerMonthLog
-from apps.month.messages.events.month import MonthPrepared
+from apps.month.messages.events.month import PlayerMonthPrepared
 
 
-@message_registry.register_event(event=MonthPrepared)
-def handle_close_all_previous_messages(*, context: MonthPrepared) -> Command:
+@message_registry.register_event(event=PlayerMonthPrepared)
+def handle_close_all_previous_messages(*, context: PlayerMonthPrepared) -> Command:
     return ClearPlayerMonthLog(savegame=context.savegame, current_month=context.current_month)

--- a/apps/month/messages/events/month.py
+++ b/apps/month/messages/events/month.py
@@ -9,29 +9,37 @@ from apps.training.models import Training
 
 
 @dataclass(kw_only=True)
-class MonthPrepared(Event):
+class FactionMonthPrepared(Event):
+    """
+    A new month has begun for one faction. Raised once per faction of the savegame, the player's
+    included - the player is a faction like any other here.
+
+    This is where anything a faction does monthly belongs. Handlers subscribe to it once and then
+    apply to everybody, which is why it carries nothing player-specific: the moment a handler needs
+    to know whose month it is, it has picked the wrong event.
+    """
+
     faction: Faction
-    savegame: Savegame
-    # None when the player faction has no training row yet - consumers have to guard
-    training: Training | None
     current_month: int
 
 
 @dataclass(kw_only=True)
-class RivalFactionMonthPrepared(Event):
+class PlayerMonthPrepared(Event):
     """
-    A new month has begun for one rival faction. Raised once per rival, next to the single
-    MonthPrepared carrying the player's faction.
+    A new month has begun for the human player specifically.
 
-    The field names deliberately match MonthPrepared's, because the two events are meant to grow
-    together: every handler that reacts to a new month by reading nothing but "faction" and
-    "current_month" can be extended to the rivals by stacking a second decorator on it, with no
-    other change. Eight of MonthPrepared's ten handlers are in that shape today. The remaining two
-    read "training" and "savegame", both of which are player-only concepts, which is why neither
-    lives on this event.
+    Only for the things a rival genuinely has no equivalent of: the town economy, the training
+    regimen, the message log. A faction of the savegame gets a FactionMonthPrepared as well, so
+    nothing here needs repeating for the player.
+
+    Moving a handler from here to FactionMonthPrepared is how a player-only activity becomes
+    something rivals do too - the field names match so that the move is the whole change.
     """
 
     faction: Faction
+    savegame: Savegame
+    # None when the player faction has no training row yet - consumers have to guard
+    training: Training | None
     current_month: int
 
 

--- a/apps/month/messages/events/month.py
+++ b/apps/month/messages/events/month.py
@@ -18,6 +18,24 @@ class MonthPrepared(Event):
 
 
 @dataclass(kw_only=True)
+class RivalFactionMonthPrepared(Event):
+    """
+    A new month has begun for one rival faction. Raised once per rival, next to the single
+    MonthPrepared carrying the player's faction.
+
+    The field names deliberately match MonthPrepared's, because the two events are meant to grow
+    together: every handler that reacts to a new month by reading nothing but "faction" and
+    "current_month" can be extended to the rivals by stacking a second decorator on it, with no
+    other change. Eight of MonthPrepared's ten handlers are in that shape today. The remaining two
+    read "training" and "savegame", both of which are player-only concepts, which is why neither
+    lives on this event.
+    """
+
+    faction: Faction
+    current_month: int
+
+
+@dataclass(kw_only=True)
 class PlayerMonthLogCreated(Event):
     player_month_log: PlayerMonthLog
 

--- a/apps/month/tests/handlers/commands/test_month.py
+++ b/apps/month/tests/handlers/commands/test_month.py
@@ -3,7 +3,7 @@ import pytest
 from apps.faction.tests.factories.faction import FactionFactory
 from apps.month.handlers.commands.month import handle_prepare_month
 from apps.month.messages.commands.month import PrepareMonth
-from apps.month.messages.events.month import RivalFactionMonthPrepared
+from apps.month.messages.events.month import FactionMonthPrepared
 from apps.savegame.tests.factories.savegame import SavegameFactory
 from apps.training.tests.factories.training import TrainingFactory
 
@@ -23,7 +23,11 @@ def test_handle_prepare_month_advances_the_month():
 
 
 @pytest.mark.django_db
-def test_handle_prepare_month_announces_the_month_for_every_rival():
+def test_handle_prepare_month_announces_the_month_for_every_faction():
+    """
+    The player's faction is announced like any other, so anything a faction does monthly reaches it
+    without a second registration.
+    """
     savegame = SavegameFactory(current_month=4)
     savegame.player_faction = FactionFactory(savegame=savegame)
     savegame.save()
@@ -31,18 +35,19 @@ def test_handle_prepare_month_announces_the_month_for_every_rival():
 
     result = handle_prepare_month(context=PrepareMonth(savegame=savegame))
 
-    assert result[1:] == [RivalFactionMonthPrepared(faction=rival_faction, current_month=5)]
+    assert result[1:] == [
+        FactionMonthPrepared(faction=savegame.player_faction, current_month=5),
+        FactionMonthPrepared(faction=rival_faction, current_month=5),
+    ]
 
 
 @pytest.mark.django_db
 def test_handle_prepare_month_leaves_out_the_factions_of_other_savegames():
     """
-    Every savegame has its own rivals, and the month of one player must not recover the warriors of
-    somebody else's.
+    Every savegame has its own factions, and the month of one player must not recover the warriors
+    of somebody else's.
     """
-    savegame = SavegameFactory(current_month=4)
-    savegame.player_faction = FactionFactory(savegame=savegame)
-    savegame.save()
+    savegame = SavegameFactory(current_month=4, player_faction=None)
     FactionFactory()
 
     result = handle_prepare_month(context=PrepareMonth(savegame=savegame))

--- a/apps/month/tests/handlers/commands/test_month.py
+++ b/apps/month/tests/handlers/commands/test_month.py
@@ -3,6 +3,7 @@ import pytest
 from apps.faction.tests.factories.faction import FactionFactory
 from apps.month.handlers.commands.month import handle_prepare_month
 from apps.month.messages.commands.month import PrepareMonth
+from apps.month.messages.events.month import RivalFactionMonthPrepared
 from apps.savegame.tests.factories.savegame import SavegameFactory
 from apps.training.tests.factories.training import TrainingFactory
 
@@ -16,9 +17,37 @@ def test_handle_prepare_month_advances_the_month():
 
     result = handle_prepare_month(context=PrepareMonth(savegame=savegame))
 
-    assert result.current_month == 5
+    assert result[0].current_month == 5
     savegame.refresh_from_db()
     assert savegame.current_month == 5
+
+
+@pytest.mark.django_db
+def test_handle_prepare_month_announces_the_month_for_every_rival():
+    savegame = SavegameFactory(current_month=4)
+    savegame.player_faction = FactionFactory(savegame=savegame)
+    savegame.save()
+    rival_faction = FactionFactory(savegame=savegame)
+
+    result = handle_prepare_month(context=PrepareMonth(savegame=savegame))
+
+    assert result[1:] == [RivalFactionMonthPrepared(faction=rival_faction, current_month=5)]
+
+
+@pytest.mark.django_db
+def test_handle_prepare_month_leaves_out_the_factions_of_other_savegames():
+    """
+    Every savegame has its own rivals, and the month of one player must not recover the warriors of
+    somebody else's.
+    """
+    savegame = SavegameFactory(current_month=4)
+    savegame.player_faction = FactionFactory(savegame=savegame)
+    savegame.save()
+    FactionFactory()
+
+    result = handle_prepare_month(context=PrepareMonth(savegame=savegame))
+
+    assert result[1:] == []
 
 
 @pytest.mark.django_db
@@ -35,7 +64,7 @@ def test_handle_prepare_month_takes_the_training_of_its_own_savegame():
 
     result = handle_prepare_month(context=PrepareMonth(savegame=savegame))
 
-    assert result.training == own_training
+    assert result[0].training == own_training
 
 
 @pytest.mark.django_db
@@ -53,7 +82,7 @@ def test_handle_prepare_month_takes_the_training_of_the_player_faction():
 
     result = handle_prepare_month(context=PrepareMonth(savegame=savegame))
 
-    assert result.training == own_training
+    assert result[0].training == own_training
 
 
 @pytest.mark.django_db
@@ -66,5 +95,5 @@ def test_handle_prepare_month_without_a_player_faction():
 
     result = handle_prepare_month(context=PrepareMonth(savegame=savegame))
 
-    assert result.training is None
-    assert result.current_month == 5
+    assert result[0].training is None
+    assert result[0].current_month == 5

--- a/apps/month/tests/test_views.py
+++ b/apps/month/tests/test_views.py
@@ -7,7 +7,9 @@ from apps.faction.tests.factories.faction import FactionFactory
 from apps.month.models.player_month_log import PlayerMonthLog
 from apps.month.tests.factories.player_month_log import PlayerMonthLogFactory
 from apps.savegame.tests.factories.savegame import SavegameFactory
+from apps.skirmish.models.warrior import Warrior
 from apps.skirmish.tests.factories.skirmish import SkirmishFactory
+from apps.skirmish.tests.factories.warrior import WarriorFactory
 from apps.training.tests.factories.training import TrainingFactory
 
 
@@ -28,6 +30,34 @@ def test_finish_month_view_advances_the_savegame_to_the_next_month(logged_in_cli
     assert response["HX-Redirect"] == reverse("account:dashboard-view")
     current_savegame.refresh_from_db()
     assert current_savegame.current_month == 2
+
+
+@pytest.mark.django_db
+def test_finish_month_view_lets_a_rival_faction_recover(logged_in_client, current_savegame):
+    """
+    Flow test rather than a unit test on purpose: that the rivals are announced at all only exists in
+    the registry, and strict mode's database blocker applies to nothing but a real queue run.
+
+    A warrior knocked unconscious in a battle keeps his condition and his health, and rivals used to
+    get no month at all - so a faction that survived one attack stayed crippled for the rest of the
+    game and could never be knocked out again. Healing lifts him above zero health, which is what
+    turns the condition back to healthy, whatever the sanctuary rolls.
+    """
+    TrainingFactory(faction=current_savegame.player_faction)
+    rival_faction = FactionFactory(savegame=current_savegame)
+    rival_warrior = WarriorFactory(
+        faction=rival_faction,
+        savegame=current_savegame,
+        condition=Warrior.ConditionChoices.CONDITION_UNCONSCIOUS,
+        current_health=0,
+        max_health=20,
+    )
+
+    response = logged_in_client.post(reverse("month:finish-month-view"))
+
+    assert response.status_code == 200
+    rival_warrior.refresh_from_db()
+    assert rival_warrior.condition == Warrior.ConditionChoices.CONDITION_HEALTHY
 
 
 @pytest.mark.django_db

--- a/apps/training/handlers/events/training.py
+++ b/apps/training/handlers/events/training.py
@@ -3,7 +3,7 @@ from queuebie.messages import Command
 
 from apps.faction.messages.events.faction import NewFactionCreated
 from apps.month.messages.commands.month import CreatePlayerMonthLog
-from apps.month.messages.events.month import MonthPrepared
+from apps.month.messages.events.month import PlayerMonthPrepared
 from apps.training.messages.commands.training import CreateNewTraining, TrainWarriors
 from apps.training.messages.events.training import WarriorUpgradedSkill
 
@@ -22,8 +22,8 @@ def handle_pub_mercenaries_restocked(*, context: WarriorUpgradedSkill) -> Comman
     )
 
 
-@message_registry.register_event(event=MonthPrepared)
-def handle_training_of_warriors_for_new_month(*, context: MonthPrepared) -> list[Command]:
+@message_registry.register_event(event=PlayerMonthPrepared)
+def handle_training_of_warriors_for_new_month(*, context: PlayerMonthPrepared) -> list[Command]:
     # A savegame whose player faction has no training row has nothing to train, and the command
     # handler dereferences "training" unguarded - finishing the month would answer with a 500
     if context.training is None:

--- a/apps/training/tests/handlers/events/test_training.py
+++ b/apps/training/tests/handlers/events/test_training.py
@@ -1,6 +1,6 @@
 from apps.faction.tests.factories.faction import FactionFactory
 from apps.month.messages.commands.month import CreatePlayerMonthLog
-from apps.month.messages.events.month import MonthPrepared
+from apps.month.messages.events.month import PlayerMonthPrepared
 from apps.savegame.tests.factories.savegame import SavegameFactory
 from apps.skirmish.tests.factories.warrior import WarriorFactory
 from apps.training.handlers.events.training import (
@@ -35,7 +35,7 @@ def test_handle_training_of_warriors_for_new_month_requests_the_training():
     training = TrainingFactory.build(faction=faction)
 
     result = handle_training_of_warriors_for_new_month(
-        context=MonthPrepared(faction=faction, savegame=savegame, training=training, current_month=3)
+        context=PlayerMonthPrepared(faction=faction, savegame=savegame, training=training, current_month=3)
     )
 
     assert result == [TrainWarriors(faction=faction, training=training, month=3)]
@@ -50,7 +50,7 @@ def test_handle_training_of_warriors_for_new_month_without_a_training():
     savegame = SavegameFactory.build()
 
     result = handle_training_of_warriors_for_new_month(
-        context=MonthPrepared(faction=faction, savegame=savegame, training=None, current_month=3)
+        context=PlayerMonthPrepared(faction=faction, savegame=savegame, training=None, current_month=3)
     )
 
     assert result == []


### PR DESCRIPTION
Rivals got no month at all: `handle_prepare_month` raised a single `MonthPrepared` carrying the player faction, so every handler on it ran for the player only. A rival that survived one battle therefore kept its unconscious and demoralised warriors for the rest of the game, and since only a healthy warrior can be fought, such a faction could never be knocked out.

## The month events are now split by concern, not by who the player is

- **`FactionMonthPrepared(faction, current_month)`** — raised once per faction of the savegame, the player's included. Anything a faction does monthly belongs here: subscribed once, applying to everybody. Morale and injury recovery live here.
- **`PlayerMonthPrepared(faction, savegame, training, current_month)`** — only for what a rival has no equivalent of: the town economy, the training regimen, the message log.

So the player is a faction like any other for anything a faction does monthly, and nothing needs a second registration to reach both.

## Extending it later

Giving rivals income or a fyrd means **moving** that handler from `PlayerMonthPrepared` to `FactionMonthPrepared` — one line, reading as "this activity is now universal". The field names match so the move is the whole change.

`Faction.objects.still_in_play()` is the single place deciding who is still taking part, so the "is this faction defeated" filter belongs there once that flag exists.

## Scope

Recovery only, deliberately. Rival income, fyrd replenishment and the defeated-faction exclusion are **not** in here — the last of those needs a `Faction.is_defeated` flag that does not exist yet.

## No behaviour change beyond the fix

The player still gets everything it got before; rivals still only recover. `test_handle_prepare_month_announces_the_month_for_every_faction` asserts the player's faction is announced, so the player silently losing its recovery would fail the suite.

The flow test `test_finish_month_view_lets_a_rival_faction_recover` was verified to fail without the change (a rival warrior stays unconscious), rather than only passing with it.

## Note on the history

The first commit on this branch raised a `RivalFactionMonthPrepared` alongside `MonthPrepared` and registered the recovery handlers on both. That worked, but it encoded "player versus rival" in the message names and made every universal activity cost two registrations and two tests. The second commit replaced it with the split above, which is why the diff removes more than it adds.
