### PR TITLE
Give the loot to the actual victor

### DIFF
--- a/apps/skirmish/handlers/commands/skirmish.py
+++ b/apps/skirmish/handlers/commands/skirmish.py
@@ -172,9 +172,8 @@ def handle_faction_wins_skirmish(*, context: skirmish.WinSkirmish) -> list[Event
         quest_loot = 0
 
     # Everything below is about the winner and the loser, so the two sides get sorted into those
-    # roles exactly once. Reaching for "player_warriors" and "non_player_warriors" directly is what
-    # made the loot follow the player rather than the victor - the two only coincide when the player
-    # wins, and the model naming invites the mistake.
+    # roles exactly once - "player_warriors" and "non_player_warriors" only coincide with them when
+    # the player happens to be the one who won
     if context.skirmish.victorious_faction == context.skirmish.player_faction:
         victorious_warriors = context.skirmish.player_warriors
         defeated_warriors = context.skirmish.non_player_warriors
@@ -182,16 +181,29 @@ def handle_faction_wins_skirmish(*, context: skirmish.WinSkirmish) -> list[Event
         victorious_warriors = context.skirmish.non_player_warriors
         defeated_warriors = context.skirmish.player_warriors
 
-    # The winner keeps the items from his dead warriors, but since it's easier they get "reassigned" to the victor,
-    # thus himself.
-    # Therefore, we reassign all dead victorious warriors items and all non-healthy defeated ones
+    # Only a warrior left lying on the field can be stripped: the dead and the unconscious. One who
+    # fled took his kit with him, so a warband that merely routs loses nothing but the fight. That
+    # distinction matters more than it looks: a defeat is declared exactly when nobody on that side
+    # is healthy any more, so "everyone not healthy" would have meant the whole roster, not its
+    # casualties.
+    defeated_warriors_on_the_field = list(
+        defeated_warriors.filter(
+            condition__in=(
+                Warrior.ConditionChoices.CONDITION_DEAD,
+                Warrior.ConditionChoices.CONDITION_UNCONSCIOUS,
+            )
+        )
+    )
+
+    # The winner's own dead take the same route, reassigned to the victor - who is their own faction,
+    # so it amounts to their gear returning to the stash. His unconscious survive and keep theirs.
     incapacitated_warriors = [
         *victorious_warriors.filter(condition=Warrior.ConditionChoices.CONDITION_DEAD),
-        *defeated_warriors.exclude(condition=Warrior.ConditionChoices.CONDITION_HEALTHY),
+        *defeated_warriors_on_the_field,
     ]
 
-    # Fetch a list of unconscious, defeated warriors
-    defeated_unconscious_warriors = defeated_warriors.filter(condition=Warrior.ConditionChoices.CONDITION_UNCONSCIOUS)
+    # The unconscious among them are the ones taken prisoner, and are already loaded above
+    defeated_unconscious_warriors = [warrior for warrior in defeated_warriors_on_the_field if warrior.is_unconscious]
 
     # Fetch list of victorious, conscious warriors
     victorious_conscious_warriors = victorious_warriors.filter(condition=Warrior.ConditionChoices.CONDITION_HEALTHY)
@@ -200,7 +212,7 @@ def handle_faction_wins_skirmish(*, context: skirmish.WinSkirmish) -> list[Event
     return SkirmishFinished(
         skirmish=context.skirmish,
         incapacitated_warriors=incapacitated_warriors,
-        defeated_unconscious_warriors=list(defeated_unconscious_warriors),
+        defeated_unconscious_warriors=defeated_unconscious_warriors,
         victorious_conscious_warriors=list(victorious_conscious_warriors),
         month=context.month,
         quest_name=quest_name,

--- a/apps/skirmish/handlers/commands/skirmish.py
+++ b/apps/skirmish/handlers/commands/skirmish.py
@@ -171,33 +171,30 @@ def handle_faction_wins_skirmish(*, context: skirmish.WinSkirmish) -> list[Event
         quest_name = None
         quest_loot = 0
 
+    # Everything below is about the winner and the loser, so the two sides get sorted into those
+    # roles exactly once. Reaching for "player_warriors" and "non_player_warriors" directly is what
+    # made the loot follow the player rather than the victor - the two only coincide when the player
+    # wins, and the model naming invites the mistake.
+    if context.skirmish.victorious_faction == context.skirmish.player_faction:
+        victorious_warriors = context.skirmish.player_warriors
+        defeated_warriors = context.skirmish.non_player_warriors
+    else:
+        victorious_warriors = context.skirmish.non_player_warriors
+        defeated_warriors = context.skirmish.player_warriors
+
     # The winner keeps the items from his dead warriors, but since it's easier they get "reassigned" to the victor,
     # thus himself.
     # Therefore, we reassign all dead victorious warriors items and all non-healthy defeated ones
     incapacitated_warriors = [
-        *context.skirmish.player_warriors.filter(condition=Warrior.ConditionChoices.CONDITION_DEAD),
-        *context.skirmish.non_player_warriors.exclude(condition=Warrior.ConditionChoices.CONDITION_HEALTHY),
+        *victorious_warriors.filter(condition=Warrior.ConditionChoices.CONDITION_DEAD),
+        *defeated_warriors.exclude(condition=Warrior.ConditionChoices.CONDITION_HEALTHY),
     ]
 
     # Fetch a list of unconscious, defeated warriors
-    if context.skirmish.victorious_faction == context.skirmish.player_faction:
-        defeated_unconscious_warriors = context.skirmish.non_player_warriors.filter(
-            condition=Warrior.ConditionChoices.CONDITION_UNCONSCIOUS
-        )
-    else:
-        defeated_unconscious_warriors = context.skirmish.player_warriors.filter(
-            condition=Warrior.ConditionChoices.CONDITION_UNCONSCIOUS
-        )
+    defeated_unconscious_warriors = defeated_warriors.filter(condition=Warrior.ConditionChoices.CONDITION_UNCONSCIOUS)
 
     # Fetch list of victorious, conscious warriors
-    if context.skirmish.victorious_faction == context.skirmish.player_faction:
-        victorious_conscious_warriors = context.skirmish.player_warriors.filter(
-            condition=Warrior.ConditionChoices.CONDITION_HEALTHY
-        )
-    else:
-        victorious_conscious_warriors = context.skirmish.non_player_warriors.filter(
-            condition=Warrior.ConditionChoices.CONDITION_HEALTHY
-        )
+    victorious_conscious_warriors = victorious_warriors.filter(condition=Warrior.ConditionChoices.CONDITION_HEALTHY)
 
     # We need to evaluate the QS to avoid hitting the DB in the events
     return SkirmishFinished(

--- a/apps/skirmish/tests/handlers/commands/test_skirmish.py
+++ b/apps/skirmish/tests/handlers/commands/test_skirmish.py
@@ -305,14 +305,22 @@ def test_handle_faction_wins_skirmish_loots_and_captures_for_the_player():
 
 @pytest.mark.django_db
 def test_handle_faction_wins_skirmish_loots_and_captures_for_the_non_player_faction():
+    """
+    The mirror image of the test above: the loot follows the victor, not the player. Naming the two
+    sides "player" and "non_player" used to make this case take the winner's items from the loser's
+    side and vice versa, so a losing player kept the gear of everyone who was merely knocked out.
+    """
     skirmish = SkirmishFactory()
     quest_contract = QuestContractFactory(faction=skirmish.player_faction, skirmish=skirmish, quest__loot=250)
     unconscious_player_warrior = WarriorFactory(
         faction=skirmish.player_faction, condition=Warrior.ConditionChoices.CONDITION_UNCONSCIOUS
     )
+    dead_enemy_warrior = WarriorFactory(
+        faction=skirmish.non_player_faction, condition=Warrior.ConditionChoices.CONDITION_DEAD
+    )
     healthy_enemy_warrior = WarriorFactory(faction=skirmish.non_player_faction)
     skirmish.player_warriors.add(unconscious_player_warrior)
-    skirmish.non_player_warriors.add(healthy_enemy_warrior)
+    skirmish.non_player_warriors.add(dead_enemy_warrior, healthy_enemy_warrior)
 
     result = handle_faction_wins_skirmish(
         context=WinSkirmish(skirmish=skirmish, victorious_faction=skirmish.non_player_faction, month=3)
@@ -320,7 +328,7 @@ def test_handle_faction_wins_skirmish_loots_and_captures_for_the_non_player_fact
 
     assert result == SkirmishFinished(
         skirmish=skirmish,
-        incapacitated_warriors=[],
+        incapacitated_warriors=[dead_enemy_warrior, unconscious_player_warrior],
         defeated_unconscious_warriors=[unconscious_player_warrior],
         victorious_conscious_warriors=[healthy_enemy_warrior],
         quest_name=quest_contract.quest.name,

--- a/apps/skirmish/tests/handlers/commands/test_skirmish.py
+++ b/apps/skirmish/tests/handlers/commands/test_skirmish.py
@@ -276,17 +276,28 @@ def test_handle_determine_attacker_and_defender_with_two_defensive_stances():
 
 @pytest.mark.django_db
 def test_handle_faction_wins_skirmish_loots_and_captures_for_the_player():
+    """
+    Both sides carry someone who is neither dead nor healthy, because that is where the two rules
+    differ: the loser's unconscious are stripped where they lie, the winner's own are not, and the
+    one who fled is gone with his kit whichever side he was on.
+    """
     skirmish = SkirmishFactory()
     quest_contract = QuestContractFactory(faction=skirmish.player_faction, skirmish=skirmish, quest__loot=250)
     dead_player_warrior = WarriorFactory(
         faction=skirmish.player_faction, condition=Warrior.ConditionChoices.CONDITION_DEAD
     )
+    unconscious_player_warrior = WarriorFactory(
+        faction=skirmish.player_faction, condition=Warrior.ConditionChoices.CONDITION_UNCONSCIOUS
+    )
     healthy_player_warrior = WarriorFactory(faction=skirmish.player_faction)
     unconscious_enemy_warrior = WarriorFactory(
         faction=skirmish.non_player_faction, condition=Warrior.ConditionChoices.CONDITION_UNCONSCIOUS
     )
-    skirmish.player_warriors.add(dead_player_warrior, healthy_player_warrior)
-    skirmish.non_player_warriors.add(unconscious_enemy_warrior)
+    fleeing_enemy_warrior = WarriorFactory(
+        faction=skirmish.non_player_faction, condition=Warrior.ConditionChoices.CONDITION_FLEEING
+    )
+    skirmish.player_warriors.add(dead_player_warrior, unconscious_player_warrior, healthy_player_warrior)
+    skirmish.non_player_warriors.add(unconscious_enemy_warrior, fleeing_enemy_warrior)
 
     result = handle_faction_wins_skirmish(
         context=WinSkirmish(skirmish=skirmish, victorious_faction=skirmish.player_faction, month=3)
@@ -301,6 +312,29 @@ def test_handle_faction_wins_skirmish_loots_and_captures_for_the_player():
         quest_loot=250,
         month=3,
     )
+
+
+@pytest.mark.django_db
+def test_handle_faction_wins_skirmish_does_not_loot_a_warband_that_fled():
+    """
+    A defeat is declared as soon as nobody on a side is healthy, so a warband can lose without
+    leaving anyone on the field. Stripping "everyone not healthy" would have cost the loser every
+    weapon and piece of armour he owns for running away.
+    """
+    skirmish = SkirmishFactory()
+    fleeing_player_warrior = WarriorFactory(
+        faction=skirmish.player_faction, condition=Warrior.ConditionChoices.CONDITION_FLEEING
+    )
+    healthy_enemy_warrior = WarriorFactory(faction=skirmish.non_player_faction)
+    skirmish.player_warriors.add(fleeing_player_warrior)
+    skirmish.non_player_warriors.add(healthy_enemy_warrior)
+
+    result = handle_faction_wins_skirmish(
+        context=WinSkirmish(skirmish=skirmish, victorious_faction=skirmish.non_player_faction, month=3)
+    )
+
+    assert result.incapacitated_warriors == []
+    assert result.defeated_unconscious_warriors == []
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
handle_faction_wins_skirmish built its "incapacitated warriors" list from player_warriors and non_player_warriors, while the comment above it says victorious and defeated. Those coincide only when the player wins, so losing a skirmish took the dead of the loser and the casualties of the winner - the exact inverse. A defeated player kept the equipment and silver of every warrior who was merely knocked out or fled, and the winning faction "looted" its own casualties.

The two sides are now sorted into winner and loser once, which also collapses the two identical branches that were translating side names into roles further down.

The test asserting the old behaviour was asserting the bug: it expected an empty loot list for a skirmish the player lost.