### PR TITLE
Stop the town shop item request reading the database in an event handler

### DIFF
--- a/apps/item/handlers/events/faction.py
+++ b/apps/item/handlers/events/faction.py
@@ -10,7 +10,6 @@ def handle_request_new_item_for_town_shop(*, context: RequestNewItemForTownShop)
     return CreateItem(
         owner=None,
         faction=context.faction,
-        savegame=context.faction.savegame,
         item_function=context.item_function,
         generator_class=context.generator_class,
         month=context.month,

--- a/apps/item/messages/commands/item.py
+++ b/apps/item/messages/commands/item.py
@@ -5,7 +5,6 @@ from queuebie.messages import Command
 from apps.faction.models.faction import Faction
 from apps.item.models.item import Item
 from apps.item.services.generators.item.base import BaseItemGenerator
-from apps.savegame.models.savegame import Savegame
 from apps.skirmish.models import Warrior
 
 
@@ -15,7 +14,6 @@ class CreateItem(Command):
     faction: Faction
     generator_class: type[BaseItemGenerator]
     item_function: int
-    savegame: Savegame
     month: int
     quality_bonus: int = 0
 

--- a/apps/item/tests/handlers/events/test_faction.py
+++ b/apps/item/tests/handlers/events/test_faction.py
@@ -1,0 +1,37 @@
+from apps.faction.messages.events.faction import RequestNewItemForTownShop
+from apps.faction.tests.factories.faction import FactionFactory
+from apps.item.handlers.events.faction import handle_request_new_item_for_town_shop
+from apps.item.messages.commands.item import CreateItem
+from apps.item.models.item_type import ItemType
+from apps.item.services.generators.item.mercenary import MercenaryItemGenerator
+
+
+def test_handle_request_new_item_for_town_shop_maps_to_command():
+    """
+    Pure mapping, so an unsaved faction is enough.
+
+    The handler used to reach through "faction.savegame" here, which is a query whenever that
+    relation is not already cached - and strict mode forbids those in an event handler. What keeps
+    it from coming back is not this test but CreateItem no longer having a savegame field at all:
+    its handler derives one from "faction.savegame_id", so there was never anything to pass.
+    """
+    faction = FactionFactory.build()
+
+    result = handle_request_new_item_for_town_shop(
+        context=RequestNewItemForTownShop(
+            faction=faction,
+            generator_class=MercenaryItemGenerator,
+            item_function=ItemType.FunctionChoices.FUNCTION_WEAPON,
+            month=3,
+            quality_bonus=2,
+        )
+    )
+
+    assert result == CreateItem(
+        owner=None,
+        faction=faction,
+        generator_class=MercenaryItemGenerator,
+        item_function=ItemType.FunctionChoices.FUNCTION_WEAPON,
+        month=3,
+        quality_bonus=2,
+    )


### PR DESCRIPTION
`handle_request_new_item_for_town_shop` passed `savegame=context.faction.savegame` into `CreateItem`. That is a query whenever the relation is not already cached, and strict mode blocks queries inside event handlers.

## Why it only sometimes exploded

Other **command** handlers in the same month chain touch `faction.savegame` first and leave it cached on that instance — `handle_restock_town_mercenaries` does it at `apps/faction/handlers/commands/warrior.py:25`. Messages carry model instances, so the item request often received an already-warmed object and the read cost nothing.

Whether that happened depended on the order the queue drained, and that order comes from queuebie autodiscovering handlers with `os.listdir`. Arbitrary on ext4, effectively sorted on NTFS — so `test_finish_month_view_advances_the_savegame_to_the_next_month` passed on Windows and failed on the Linux runner with `DatabaseAccessDeniedError`.

## The fix

Nothing needed the value. `handle_create_item` derives the savegame from `faction.savegame_id` and never read `CreateItem.savegame`, and `CreateItem` is constructed in exactly one place — so the field is deleted rather than supplied from somewhere safer.

That makes the traversal **unreachable** instead of merely unnecessary: `savegame=` is now a `TypeError`, so the bug cannot be reintroduced by accident. Net diff against main is three deletions.

Also adds the unit test the handler never had — reverting the fix previously left the suite fully green.

## Note for reviewers

No unit test can catch this class of bug: the blocker is applied by `handle_message()`, so calling a handler directly bypasses it. The flow test found it, and only on Linux. A green local run says nothing about strict-mode compliance.

The first version of this PR threaded a `savegame` field through `RequestNewItemForTownShop` instead. A review pointed out the consumer discards it, so that approach was replaced with the deletion above.