### PR TITLE
Added the implement-story skill

### DIFF
--- a/.claude/skills/implement-story/SKILL.md
+++ b/.claude/skills/implement-story/SKILL.md
@@ -1,0 +1,208 @@
+---
+name: implement-story
+description: Implement a story end to end - resolve it from a GitHub issue link, issue number or plain text, plan it, write it, get the local CI gates green, run a resumable sharded code review that never blocks on a dying reviewer, fix what it finds, then commit, push and open the PR. Use when asked to implement an issue or story, or to resume an interrupted run.
+---
+
+# Implement a story
+
+One story, from issue to open PR, with a code review that survives its own reviewers dying.
+
+## Usage
+
+```
+/implement-story <github issue url | issue number | free text describing the story>
+/implement-story --resume [slug]        # pick an interrupted run back up
+/implement-story <story> --native       # use the built-in /code-review instead of sharded review
+/implement-story <story> --deadline=900 # review wall-clock budget in seconds (default 720)
+/implement-story <story> --no-pr        # stop after pushing, do not open the PR
+```
+
+## The run directory
+
+Everything durable lives in `.claude/runs/<slug>/` (gitignored). This directory *is* the state - it is
+what makes a dead reviewer cost one lens instead of the whole run.
+
+```
+.claude/runs/<slug>/
+  spec.md              the story, resolved once, never re-fetched
+  plan.md              the approved implementation plan
+  state.json           phase, branch, shard status, attempt counts
+  ci.md                latest gate results
+  ci-logs/             full pre-commit and pytest output
+  review/
+    .started_at        epoch seconds, written when the round launches
+    .head_sha          the commit the round is reviewing
+    01-correctness.md  each shard writes its own file, incrementally
+    02-data-layer.md
+    03-tests.md
+    04-conformance.md
+  findings.md          merged, deduped, triaged
+```
+
+A shard file ending in the line `<!-- shard-complete -->` is finished. A shard file **without** it is a
+partial and is still used - its findings count, its coverage is reported as incomplete. No file at all
+means that lens was never reviewed, which is reported as a gap rather than blocking the run.
+
+## Before you start
+
+Read [AGENTS.md](../../../AGENTS.md) and the docs it points at for the area you are about to touch. They
+are normative, and this project deviates from Django defaults on purpose. Do not infer conventions from
+nearby code.
+
+## Phase 0 - Resolve the story
+
+Derive `<slug>` as a short kebab-case name for the story (`faction-defeat`, `town-shop-restock`).
+
+- **Issue URL or number** - `gh issue view <n> --json number,title,body,labels,comments`. Write the title,
+  body and any comment that changes the requirements into `spec.md`. Record the issue number in
+  `state.json`; it becomes `Closes #<n>` in the PR.
+- **Free text** - write it into `spec.md` verbatim, then add your reading of it underneath as
+  "Interpretation". No issue number.
+
+Resolve once. Later phases read `spec.md`, they do not re-fetch.
+
+If the working tree is dirty or a rebase/merge is in progress, stop and say so. Do not start a story on
+top of someone else's half-finished work.
+
+## Phase 1 - Plan, then stop
+
+Create the branch from an up-to-date `main`: `feature/<slug>` for new behaviour, `fix/<slug>` for a
+defect, `chore/<slug>` for maintenance. The remote is `github`, not `origin`.
+
+Write `plan.md`: the files you will touch, the messages/handlers you will add, the tests you will write,
+and anything in the story you consider out of scope. Follow
+[adding a new flow](../../../docs/patterns/adding-a-flow.md) if the story crosses the message bus.
+
+**Present the plan and stop for approval.** This is the only mandatory stop in the run.
+
+## Phase 2 - Implement
+
+Work the plan. Tests are part of the story, not a follow-up - see
+[testing strategy](../../../docs/patterns/testing-strategy.md) before writing any of them.
+
+Keep commits in logical chunks as you go, following
+[commit messages](../../../docs/contributing/commit-messages.md): one capitalized subject line, no
+trailing period, no issue tag.
+
+## Phase 3 - CI gates
+
+```bash
+bash .claude/skills/implement-story/scripts/ci.sh .claude/runs/<slug>
+```
+
+Runs the same two gates as `.github/workflows/tests.yml`: `pre-commit run --all-files` (twice, because the
+formatting hooks fail the run they rewrote) and `uv run pytest --cov` behind the 100% branch gate. Results
+land in `ci.md`, full output in `ci-logs/`.
+
+Fix and re-run until both are green. **The review does not start on a red run** - reviewers must not spend
+wall-clock on findings a linter would have caught for free. If coverage is short, read
+[coverage](../../../docs/patterns/coverage.md): the fix is a test, never `# pragma: no cover` and never a
+lower `fail_under`.
+
+## Phase 4 - Sharded code review
+
+With `--native`, skip this phase and invoke `/code-review` instead, then jump to Phase 5.
+
+### Launch
+
+1. `git diff main...HEAD --stat` - count changed lines and decide the shard count:
+
+   | Changed lines | Shards |
+   |---|---|
+   | up to 200 | 1 |
+   | up to 600 | 2 |
+   | up to 1200 | 3 |
+   | more | 4 |
+
+   Take them in the order listed in [review lenses](references/review-lenses.md) - the lenses are ranked,
+   so a small diff drops the least valuable ones and a deadline drops them too.
+2. Write `review/.started_at` (`date +%s`) and `review/.head_sha` (`git rev-parse HEAD`).
+3. Launch every shard **in a single message** so they run concurrently, one `Agent` call each with
+   `subagent_type: "general-purpose"` and `model: "sonnet"`. Build each prompt from the template in
+   [review lenses](references/review-lenses.md). Record the returned agent ids in `state.json`.
+
+### Wait
+
+Shard completions arrive as task notifications. On each one:
+
+```bash
+bash .claude/skills/implement-story/scripts/review-status.sh .claude/runs/<slug>
+```
+
+It prints elapsed seconds against the deadline and the per-shard state (`complete`, `partial`, `missing`).
+Do not poll it on a timer - only look when a notification wakes you, or when you have nothing else to do.
+
+**Never re-read a shard's returned text as the source of truth.** The file is the deliverable. An agent
+that returns nothing but left a complete file succeeded.
+
+### Retry, once
+
+A shard is failed when its agent returns an error, or dies, or leaves no file. Retry it exactly once, with
+the scope halved - hand the retry only the largest changed files by line count, and say so in the prompt.
+Bump `attempts` in `state.json`. A second failure is a gap, not a third attempt.
+
+### Deadline
+
+When elapsed exceeds the deadline (default 720s, `--deadline=N` to change it):
+
+1. `TaskStop` any shard still running.
+2. Anything with a partial file keeps its findings, marked incomplete.
+3. Anything with no file is recorded in `findings.md` as
+   `Not reviewed: <lens> - <reason>` and the run continues.
+
+Continuing with a gap is the correct outcome, not a failure. Say plainly which lens was skipped so the
+cost of continuing is visible.
+
+### Merge
+
+Read every shard file that exists. Drop findings below confidence 80, drop exact duplicates and collapse
+near-duplicates on the same file and line, keeping the clearest wording. Write the survivors to
+`findings.md`, most severe first, with the not-reviewed gaps listed at the bottom.
+
+Then call `ReportFindings` with the merged set so they render as a navigable list rather than a wall of
+markdown.
+
+## Phase 5 - Triage and fix
+
+Fix everything that is a real defect in code this story touched. Do not fix pre-existing problems in
+passing - note them in `findings.md` under "Out of scope, worth a follow-up" and mention them in the final
+report. One feature turning up five other things is normal here; the discipline is naming them, not doing
+them.
+
+Re-run `ci.sh`. **Do not re-run the review.** Instead, if the fixes were non-trivial, launch a single
+`Agent` to check only `git diff <head_sha_from_review>..HEAD` for regressions the fixes introduced. A full
+second review round is the single most expensive thing this skill could do and it is almost never worth
+it.
+
+## Phase 6 - Ship
+
+Commit the fixes, push with `git push -u github <branch>`, and open the PR:
+
+```bash
+gh pr create --base main --title "<story title>" --body-file <body>
+```
+
+The body carries: what the story asked for, what you built, `Closes #<n>` when there is an issue, the CI
+result, and a **Review coverage** line naming any lens that was skipped or partial. Unless `--no-pr`.
+
+End with a short report: what shipped, what CI said, what the review found and what you fixed, what was
+skipped and why, and the out-of-scope list.
+
+## Resuming
+
+`state.json` carries `phase`. On `--resume`, read it and re-enter at that phase. Within Phase 4, relaunch
+only the shards whose status is not `complete`, and only if `review/.head_sha` still matches `HEAD` - if
+the code moved on, the round is stale, so start a fresh one.
+
+If a run is interrupted anywhere, the run directory is enough to continue. Never restart from Phase 0 when
+`spec.md` already exists.
+
+## Cost rules
+
+The point of the sharding is to spend wall-clock once. Hold these:
+
+- Review the diff against `main`, never the repository.
+- Never re-run a shard that produced a complete file.
+- Never re-review after fixes; check the fix delta instead.
+- Never spend review wall-clock on anything `ruff`, `boa-restrictor` or the coverage gate already catches.
+- One retry per shard, at half scope. Then it is a gap.

--- a/.claude/skills/implement-story/SKILL.md
+++ b/.claude/skills/implement-story/SKILL.md
@@ -43,6 +43,32 @@ A shard file ending in the line `<!-- shard-complete -->` is finished. A shard f
 partial and is still used - its findings count, its coverage is reported as incomplete. No file at all
 means that lens was never reviewed, which is reported as a gap rather than blocking the run.
 
+`state.json` is what a later session resumes from, so its shape is fixed rather than improvised:
+
+```json
+{
+  "slug": "faction-defeat",
+  "issue": 21,
+  "branch": "feature/faction-defeat",
+  "base": "main",
+  "phase": "review",
+  "deadline_seconds": 720,
+  "ci_attempts": 2,
+  "review": {
+    "head_sha": "c753616",
+    "shards": {
+      "01-correctness": { "status": "complete", "attempts": 1, "agent_id": "agent_x" },
+      "02-data-layer":  { "status": "running",  "attempts": 2, "agent_id": "agent_y" },
+      "03-tests":       { "status": "gap",      "attempts": 2, "reason": "deadline" }
+    }
+  }
+}
+```
+
+`phase` is one of `spec`, `plan`, `implement`, `ci`, `review`, `triage`, `ship`. A shard `status` is one
+of `running`, `complete`, `partial`, `gap`. Write the file after every phase transition and every shard
+state change - it is cheap, and it is the only thing standing between an interrupted run and a restart.
+
 ## Before you start
 
 Read [AGENTS.md](../../../AGENTS.md) and the docs it points at for the area you are about to touch. They
@@ -94,18 +120,31 @@ Runs the same two gates as `.github/workflows/tests.yml`: `pre-commit run --all-
 formatting hooks fail the run they rewrote) and `uv run pytest --cov` behind the 100% branch gate. Results
 land in `ci.md`, full output in `ci-logs/`.
 
-Fix and re-run until both are green. **The review does not start on a red run** - reviewers must not spend
-wall-clock on findings a linter would have caught for free. If coverage is short, read
-[coverage](../../../docs/patterns/coverage.md): the fix is a test, never `# pragma: no cover` and never a
-lower `fail_under`.
+Fix and re-run until both are green, counting rounds in `ci_attempts`. **The review does not start on a
+red run** - reviewers must not spend wall-clock on findings a linter would have caught for free. If
+coverage is short, read [coverage](../../../docs/patterns/coverage.md): the fix is a test, never
+`# pragma: no cover` and never a lower `fail_under`.
+
+The formatting hooks rewrite files, so stage whatever they changed before the next commit - see
+[linting](../../../docs/contributing/linting.md).
+
+**After three red rounds, stop and report.** Three failures on the same gate means the plan was wrong, not
+that the fix needs another attempt, and grinding on it is exactly the wall-clock this skill exists to
+protect. Say what is failing and what you tried.
 
 ## Phase 4 - Sharded code review
 
-With `--native`, skip this phase and invoke `/code-review` instead, then jump to Phase 5.
+With `--native`, skip this phase and invoke `/code-review` instead. Then go to Phase 5, but skip its
+delta check - there is no review `head_sha` to diff against, and the native review already covered the
+change.
 
 ### Launch
 
-1. `git diff main...HEAD --stat` - count changed lines and decide the shard count:
+1. **`git status --porcelain` must be empty.** Commit everything first. The shards review
+   `git diff main...HEAD`, so uncommitted work is invisible to all of them and the round would come back
+   clean having reviewed nothing - the one failure this design must not have. Do not launch on a dirty
+   tree.
+2. `git diff main...HEAD --stat` - count changed lines and decide the shard count:
 
    | Changed lines | Shards |
    |---|---|
@@ -116,8 +155,8 @@ With `--native`, skip this phase and invoke `/code-review` instead, then jump to
 
    Take them in the order listed in [review lenses](references/review-lenses.md) - the lenses are ranked,
    so a small diff drops the least valuable ones and a deadline drops them too.
-2. Write `review/.started_at` (`date +%s`) and `review/.head_sha` (`git rev-parse HEAD`).
-3. Launch every shard **in a single message** so they run concurrently, one `Agent` call each with
+3. Write `review/.started_at` (`date +%s`) and `review/.head_sha` (`git rev-parse HEAD`).
+4. Launch every shard **in a single message** so they run concurrently, one `Agent` call each with
    `subagent_type: "general-purpose"` and `model: "sonnet"`. Build each prompt from the template in
    [review lenses](references/review-lenses.md). Record the returned agent ids in `state.json`.
 
@@ -126,8 +165,11 @@ With `--native`, skip this phase and invoke `/code-review` instead, then jump to
 Shard completions arrive as task notifications. On each one:
 
 ```bash
-bash .claude/skills/implement-story/scripts/review-status.sh .claude/runs/<slug>
+bash .claude/skills/implement-story/scripts/review-status.sh .claude/runs/<slug> <deadline_seconds>
 ```
+
+Pass the deadline explicitly - the script defaults to 720 and would otherwise measure a `--deadline=900`
+run against the wrong budget, cutting shards short without saying so.
 
 It prints elapsed seconds against the deadline and the per-shard state (`complete`, `partial`, `missing`).
 Do not poll it on a timer - only look when a notification wakes you, or when you have nothing else to do.

--- a/.claude/skills/implement-story/references/review-lenses.md
+++ b/.claude/skills/implement-story/references/review-lenses.md
@@ -1,0 +1,99 @@
+# Review lenses and the shard prompt
+
+Four lenses, ranked. A small diff uses the first N; a deadline cuts from the bottom. The ranking is by how
+expensive the class of bug is to find later, not by how often it fires.
+
+| # | File | Lens | Normative docs the shard must read first |
+|---|---|---|---|
+| 01 | `01-correctness.md` | Correctness and message-bus wiring | [message-bus](../../../../docs/patterns/message-bus.md), [handlers](../../../../docs/patterns/handlers.md), [strict-mode](../../../../docs/patterns/strict-mode.md), [registry-tests](../../../../docs/patterns/registry-tests.md) |
+| 02 | `02-data-layer.md` | Data layer, savegame scoping and migrations | [savegame-scoping](../../../../docs/patterns/savegame-scoping.md), [app-layout](../../../../docs/patterns/app-layout.md), [town-buildings](../../../../docs/patterns/town-buildings.md) |
+| 03 | `03-tests.md` | Test honesty and coverage substance | [testing-strategy](../../../../docs/patterns/testing-strategy.md), [testing-conventions](../../../../docs/patterns/testing-conventions.md), [testing-data](../../../../docs/patterns/testing-data.md), [mocking](../../../../docs/patterns/mocking.md), [coverage](../../../../docs/patterns/coverage.md) |
+| 04 | `04-conformance.md` | Spec conformance and simplification | `spec.md`, [app-layout](../../../../docs/patterns/app-layout.md) |
+
+### What each lens is looking for
+
+**01 Correctness and message-bus wiring.** Logic that is wrong for inputs the story will actually produce.
+Commands emitted with no handler. Handlers that mutate and return nothing where an event was owed. The
+golden rule violated in either direction. Querysets left unevaluated on a message. `context` not
+keyword-only. Off-by-one and inverted conditions in the game rules the story changed.
+
+**02 Data layer, savegame scoping and migrations.** A model object resolved in a view without the scoping
+mixins - a savegame leak is silent and this is the lens that catches it. Queries in loops. Missing
+`select_related`/`prefetch_related` on a path the story made hot. A migration that will not apply on an
+existing database, or model changes with no migration at all. Game-balance numbers written somewhere other
+than where the docs put them.
+
+**03 Test honesty and coverage substance.** Coverage that is reached without asserting anything. First-party
+code mocked - the docs call that a review finding outright. Branches covered by patching the thing under
+test rather than exercising it. A branch behind unpatched randomness, which makes the gate pass by chance.
+Tests that would still pass if the story's change were reverted.
+
+**04 Spec conformance and simplification.** Requirements in `spec.md` that the diff does not actually
+satisfy, and behaviour in the diff that nothing in `spec.md` asked for. Code duplicated from somewhere it
+could have been reused. Abstraction introduced for one caller. Dead branches left behind by the change.
+
+## Shard prompt template
+
+Fill the placeholders and pass this as the `Agent` prompt. Keep the wording - the incremental-write rule
+and the verify stage are what make a dying shard cheap and a surviving shard trustworthy.
+
+---
+
+You are reviewing one lens of a code change in the Tettenhall repository at `<REPO_ROOT>`.
+
+**Your deliverable is the file `<RUN_DIR>/review/<SHARD_FILE>`, not your reply.** Nothing you return in
+chat is read. Write findings into that file as you confirm them, one at a time, appending - never buffer
+them to the end. If you are killed halfway through, everything already written still counts, and that is
+the point.
+
+The change under review is `git diff main...HEAD`<SCOPE_NOTE>. Review only that diff. Problems on lines
+this change did not touch are out of scope.
+
+**Your lens: <LENS_NAME>.** <LENS_DESCRIPTION>
+
+Read these before you review - they are normative for this project, which deviates from Django defaults on
+purpose: <LENS_DOCS>. Also read `<RUN_DIR>/spec.md` for what the change was supposed to do.
+
+Work in two stages, per finding:
+
+1. **Find.** Scan the diff through your lens and note candidates.
+2. **Verify.** For each candidate, go back to the actual code and try to *refute* it. Read the
+   surrounding function, the callers, the tests. Then score your confidence 0-100 that it is a real defect
+   a reviewer should raise: 100 you confirmed it end to end, 80 you verified it and it will bite in
+   practice, 50 real but a nitpick, 25 you could not verify it, 0 refuted. **Write it to the file only if
+   it scores 80 or higher.** Default to refuting when you are unsure - a false positive costs the
+   maintainer more time than a missed nitpick.
+
+Do not report: anything `ruff`, `boa-restrictor` or the 100% branch coverage gate already catches (they
+run before you and are green); formatting and import order; pre-existing problems; style a senior
+engineer would not raise in review; changes that are obviously intentional parts of the story.
+
+Append each surviving finding in exactly this format:
+
+```finding
+file: apps/skirmish/handlers/commands/skirmish.py
+line: 42
+severity: high | medium | low
+category: <short-kebab-slug>
+claim: One sentence stating the defect.
+scenario: Concrete inputs or state, then the wrong output or crash that follows.
+confidence: 85
+```
+
+When you have finished the whole lens, append this line and nothing after it:
+
+`<!-- shard-complete -->`
+
+If you find nothing, still append the sentinel - a complete file with no findings is a real result and
+stops the orchestrator from retrying you.
+
+---
+
+## Retry variant
+
+On the single permitted retry, keep the prompt identical but replace `<SCOPE_NOTE>` with:
+
+> , narrowed for this retry to these files only: `<FILE_LIST>` (the largest by changed lines; the rest of
+> the diff is out of scope for you).
+
+and note in the merged `findings.md` that the lens ran at reduced scope.

--- a/.claude/skills/implement-story/scripts/ci.sh
+++ b/.claude/skills/implement-story/scripts/ci.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Runs the two gates from .github/workflows/tests.yml locally and records the outcome.
+#
+# Usage: bash .claude/skills/implement-story/scripts/ci.sh .claude/runs/<slug>
+# Exit code: 0 when both gates pass, 1 otherwise.
+
+set -uo pipefail
+
+RUN_DIR="${1:?usage: ci.sh <run-dir>}"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT" || exit 1
+
+case "$RUN_DIR" in
+  /*) ;;
+  *) RUN_DIR="$REPO_ROOT/$RUN_DIR" ;;
+esac
+
+LOG_DIR="$RUN_DIR/ci-logs"
+mkdir -p "$LOG_DIR"
+OUT="$RUN_DIR/ci.md"
+
+# The formatting hooks rewrite files and then fail the very run that rewrote them, so a single red pass
+# proves nothing. The second pass on the rewritten tree is the honest signal - hence a retry, not a loop.
+pre-commit run --all-files > "$LOG_DIR/pre-commit.log" 2>&1
+lint_status=$?
+lint_passes=1
+if [ $lint_status -ne 0 ]; then
+  pre-commit run --all-files > "$LOG_DIR/pre-commit.log" 2>&1
+  lint_status=$?
+  lint_passes=2
+fi
+
+# Coverage config lives in pyproject.toml and fails below 100% branch coverage, so this one command is
+# both the test gate and the coverage gate.
+uv run pytest --cov > "$LOG_DIR/pytest.log" 2>&1
+test_status=$?
+
+verdict() { [ "$1" -eq 0 ] && echo "PASS" || echo "FAIL"; }
+
+{
+  echo "# CI gates"
+  echo
+  echo "Commit: \`$(git rev-parse --short HEAD 2>/dev/null || echo unknown)\` on branch \`$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)\`"
+  echo
+  echo "| Gate | Command | Result |"
+  echo "|---|---|---|"
+  echo "| Lint | \`pre-commit run --all-files\` ($lint_passes pass(es)) | $(verdict $lint_status) |"
+  echo "| Tests + coverage | \`uv run pytest --cov\` | $(verdict $test_status) |"
+  echo
+  if [ $lint_status -ne 0 ]; then
+    echo "## pre-commit (last 60 lines)"
+    echo
+    echo '```'
+    tail -n 60 "$LOG_DIR/pre-commit.log"
+    echo '```'
+    echo
+  fi
+  if [ $test_status -ne 0 ]; then
+    echo "## pytest (last 80 lines)"
+    echo
+    echo '```'
+    tail -n 80 "$LOG_DIR/pytest.log"
+    echo '```'
+    echo
+  fi
+  echo "Full output: \`${LOG_DIR#"$REPO_ROOT/"}/\`"
+} > "$OUT"
+
+cat "$OUT"
+
+if [ $lint_status -eq 0 ] && [ $test_status -eq 0 ]; then
+  exit 0
+fi
+exit 1

--- a/.claude/skills/implement-story/scripts/review-status.sh
+++ b/.claude/skills/implement-story/scripts/review-status.sh
@@ -39,7 +39,10 @@ found=0
 for f in "$REVIEW_DIR"/*.md; do
   found=1
   name=$(basename "$f")
-  findings=$(grep -c '^```finding' "$f" 2>/dev/null || echo 0)
+  # "grep -c" prints its count and still exits 1 when that count is zero, so a "|| echo 0" fallback
+  # would append a second zero and split the line. Swallow the exit code, keep the count.
+  findings=$(grep -c '^```finding' "$f" 2>/dev/null || true)
+  findings=${findings:-0}
   # The sentinel is the only thing that distinguishes a finished lens from one that died mid-write.
   if tail -n 5 "$f" | grep -q -- '<!-- shard-complete -->'; then
     state="complete"

--- a/.claude/skills/implement-story/scripts/review-status.sh
+++ b/.claude/skills/implement-story/scripts/review-status.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Reports how the sharded review round is doing: wall-clock against the deadline, and the state of every
+# shard file. Cheap enough to call on every task notification; it reads files, it never waits.
+#
+# Usage: bash .claude/skills/implement-story/scripts/review-status.sh .claude/runs/<slug> [deadline_seconds]
+
+set -uo pipefail
+
+RUN_DIR="${1:?usage: review-status.sh <run-dir> [deadline_seconds]}"
+DEADLINE="${2:-720}"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+
+case "$RUN_DIR" in
+  /*) ;;
+  *) RUN_DIR="$REPO_ROOT/$RUN_DIR" ;;
+esac
+
+REVIEW_DIR="$RUN_DIR/review"
+if [ ! -d "$REVIEW_DIR" ]; then
+  echo "no review round started (missing $REVIEW_DIR)"
+  exit 1
+fi
+
+now=$(date +%s)
+started=$(cat "$REVIEW_DIR/.started_at" 2>/dev/null || echo "$now")
+elapsed=$(( now - started ))
+remaining=$(( DEADLINE - elapsed ))
+
+if [ $remaining -gt 0 ]; then
+  echo "elapsed ${elapsed}s / deadline ${DEADLINE}s - ${remaining}s left"
+else
+  echo "elapsed ${elapsed}s / deadline ${DEADLINE}s - DEADLINE PASSED, stop stragglers and continue"
+fi
+echo "reviewing $(cat "$REVIEW_DIR/.head_sha" 2>/dev/null || echo 'unknown sha')"
+echo
+
+shopt -s nullglob
+found=0
+for f in "$REVIEW_DIR"/*.md; do
+  found=1
+  name=$(basename "$f")
+  findings=$(grep -c '^```finding' "$f" 2>/dev/null || echo 0)
+  # The sentinel is the only thing that distinguishes a finished lens from one that died mid-write.
+  if tail -n 5 "$f" | grep -q -- '<!-- shard-complete -->'; then
+    state="complete"
+  else
+    state="partial "
+  fi
+  printf '%-24s %s  %s finding(s)\n' "$name" "$state" "$findings"
+done
+
+if [ $found -eq 0 ]; then
+  echo "(no shard files yet)"
+fi
+
+echo
+echo "Any lens you launched with no file above is missing: retry it once, then record it as a gap."

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Shell scripts must keep LF endings. Git's autocrlf would otherwise hand a Windows clone a script whose
+# shebang line ends in \r, which bash rejects as a bad interpreter.
+*.sh text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ __pycache__/
 .ruff_cache/
 .coverage
 htmlcov/
+
+# Scratch state for the /implement-story skill: specs, plans, CI logs and review shards.
+.claude/runs/


### PR DESCRIPTION
Drives a story from a GitHub issue link, issue number or plain description through plan, implementation, the two local CI gates and a code review, to an open PR. It stops once, for plan approval.

## Why the review is sharded

A single reviewer over a whole change is slow enough that it regularly dies, and a death costs the entire round — the expensive part gets paid twice. This splits the diff into up to four ranked lenses (correctness and message-bus wiring, data layer and savegame scoping, test honesty, spec conformance), one agent each, sized by how large the diff is.

Every agent appends findings to its own file as it confirms them rather than returning them at the end, and marks the file complete with a sentinel. So:

- a lens that dies mid-write leaves a usable partial, and its findings still count;
- a lens that never lands is retried exactly once at half scope, then recorded as `Not reviewed: <lens>` and the run continues;
- finishing with an honest hole beats blocking.

State lives in a gitignored `.claude/runs/<slug>/`. `state.json` has a fixed documented shape, so a later session resumes rather than restarting, relaunching only the shards that are not already complete — and only if the reviewed `head_sha` still matches `HEAD`.

A review round refuses to launch on a dirty working tree. The shards read `git diff main...HEAD`, so uncommitted work would be invisible to all of them and the round would come back clean having reviewed nothing. That silent under-review is the one failure this design must not have.

## What it keeps from the built-in review

Each lens runs a find-then-refute stage and drops anything under 80 confidence — a false positive costs more of the maintainer's time than a missed nitpick. The merged set goes through `ReportFindings` so it renders as a navigable list. `--native` hands off to `/code-review` when the full thing is wanted.

## Cost rules

Encoded in the skill, because this is where wall-clock actually goes: review `main...HEAD` and never the repository, never re-run a complete shard, never spend review time on anything `ruff`, `boa-restrictor` or the coverage gate already catches, and never re-review after fixing findings — only the fix delta gets a second look. The CI fix loop stops after three red rounds instead of grinding: three failures on the same gate mean the plan was wrong, not that the fix needs another attempt.

## Contents

- `.claude/skills/implement-story/SKILL.md` — the phases, the run-directory contract and the `state.json` schema
- `.claude/skills/implement-story/references/review-lenses.md` — the four lenses and the shard prompt
- `.claude/skills/implement-story/scripts/ci.sh` — runs the same two gates as `.github/workflows/tests.yml`, with the pre-commit retry the formatting hooks need
- `.claude/skills/implement-story/scripts/review-status.sh` — elapsed against deadline, per-shard state

`.gitattributes` is new and pins `*.sh` to LF, otherwise a Windows clone gets scripts whose shebang ends in `\r`.

## Review

The second commit applies a review of the first. Two findings were worth the round trip: the missing clean-tree precondition described above, and a status-script bug where `grep -c` prints its zero *and* exits non-zero, so the `|| echo 0` fallback appended a second zero and split the count onto its own row — which fired on every lens that found nothing, i.e. the normal successful case. Five smaller ones: the `--deadline` override was never passed to the script measuring it, `state.json` was unspecified, the CI loop was unbounded, `--native` sent Phase 5 hunting a `head_sha` it never wrote, and Phase 3 omitted the re-staging step `docs/contributing/linting.md` calls out.

Two known trade-offs left in deliberately. Shard count follows diff size rather than which lenses are relevant, so a small handler change gets the correctness lens but not the savegame-scoping one — sizing by relevance would cost more wall-clock, and this is the choice that favours time. And `--native` can disagree with the sharded path, which is inherent to keeping the escape hatch.

Both scripts were exercised on every path: green, lint-retry, failing tests, deadline passed, zero-finding and partial vs complete shard detection. No application code is touched, so CI here only proves the repo is still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
