### PR TITLE
Capture a warrior once, however many fights he was in

### DIFF
--- a/apps/savegame/tests/test_flows.py
+++ b/apps/savegame/tests/test_flows.py
@@ -45,6 +45,40 @@ def test_losing_the_leader_ends_the_game_and_decides_the_open_fight(queuebie_reg
 
 
 @pytest.mark.django_db
+def test_a_warrior_in_two_open_fights_is_taken_prisoner_only_once(queuebie_registry):
+    """
+    Ending the game decides every unresolved skirmish in one pass, so a warrior standing on two
+    rosters is processed as a casualty twice. He used to end up in both victors' cells at once.
+
+    A flow test rather than a unit test because that is the whole defect: the capture handler is
+    correct on its own and only misbehaves when the force-resolve above it calls it a second time.
+    """
+    savegame = SavegameFactory()
+    player_faction = FactionFactory(savegame=savegame)
+    savegame.player_faction = player_faction
+    savegame.save()
+    first_rival = FactionFactory(savegame=savegame)
+    second_rival = FactionFactory(savegame=savegame)
+
+    leader = WarriorFactory(
+        faction=player_faction, savegame=savegame, condition=Warrior.ConditionChoices.CONDITION_UNCONSCIOUS
+    )
+    player_faction.leader = leader
+    player_faction.save()
+
+    # He was committed to both fights, and neither has been played out
+    for rival_faction in (first_rival, second_rival):
+        skirmish = SkirmishFactory(player_faction=player_faction, non_player_faction=rival_faction)
+        skirmish.player_warriors.add(leader)
+        skirmish.non_player_warriors.add(WarriorFactory(faction=rival_faction, savegame=savegame))
+
+    handle_message(DefeatFactionOfLostLeader(warrior=leader))
+
+    assert list(first_rival.captured_warriors.all()) == [leader]
+    assert list(second_rival.captured_warriors.all()) == []
+
+
+@pytest.mark.django_db
 def test_losing_the_last_rival_wins_the_game(queuebie_registry):
     savegame = SavegameFactory()
     player_faction = FactionFactory(savegame=savegame)

--- a/apps/savegame/tests/test_flows.py
+++ b/apps/savegame/tests/test_flows.py
@@ -67,10 +67,12 @@ def test_a_warrior_in_two_open_fights_is_taken_prisoner_only_once(queuebie_regis
     player_faction.save()
 
     # He was committed to both fights, and neither has been played out
-    for rival_faction in (first_rival, second_rival):
-        skirmish = SkirmishFactory(player_faction=player_faction, non_player_faction=rival_faction)
-        skirmish.player_warriors.add(leader)
-        skirmish.non_player_warriors.add(WarriorFactory(faction=rival_faction, savegame=savegame))
+    first_skirmish = SkirmishFactory(player_faction=player_faction, non_player_faction=first_rival)
+    first_skirmish.player_warriors.add(leader)
+    first_skirmish.non_player_warriors.add(WarriorFactory(faction=first_rival, savegame=savegame))
+    second_skirmish = SkirmishFactory(player_faction=player_faction, non_player_faction=second_rival)
+    second_skirmish.player_warriors.add(leader)
+    second_skirmish.non_player_warriors.add(WarriorFactory(faction=second_rival, savegame=savegame))
 
     handle_message(DefeatFactionOfLostLeader(warrior=leader))
 

--- a/apps/skirmish/handlers/commands/warrior.py
+++ b/apps/skirmish/handlers/commands/warrior.py
@@ -52,7 +52,22 @@ def handle_store_last_used_skirmish_action(*, context: warrior.StoreLastUsedSkir
 
 
 @message_registry.register_command(command=warrior.CaptureWarrior)
-def handle_warrior_is_captured(*, context: warrior.CaptureWarrior) -> list[Event] | Event:
+def handle_warrior_is_captured(*, context: warrior.CaptureWarrior) -> list[Event] | Event | None:
+    """
+    Takes the warrior prisoner, unless somebody already has him.
+
+    A warrior can stand on the roster of more than one unresolved skirmish, and ending the game
+    decides every one of them in a single pass - so this runs once per fight he was in. Taking him
+    twice left the same man sitting in two factions' cells at once, and announced a capture that
+    emptied a faction which had already lost him.
+
+    Asked of the captor relation rather than of "warrior.faction is None", because that is what
+    being a prisoner actually means here: a warrior with no faction is also what a capture leaves
+    behind, so reading it would refuse the very first capture as well.
+    """
+    if Faction.objects.filter(captured_warriors=context.warrior).exists():
+        return None
+
     Faction.objects.add_captive(faction=context.capturing_faction, warrior=context.warrior)
     context.warrior.faction = None
     context.warrior.save()

--- a/apps/skirmish/tests/handlers/commands/test_warrior.py
+++ b/apps/skirmish/tests/handlers/commands/test_warrior.py
@@ -59,6 +59,29 @@ def test_handle_warrior_is_captured_takes_the_warrior_out_of_his_faction():
 
 
 @pytest.mark.django_db
+def test_handle_warrior_is_captured_leaves_an_existing_prisoner_where_he_is():
+    """
+    A warrior can be on the roster of two unresolved skirmishes, and ending the game decides both in
+    one pass - so this runs twice for him. The second captor does not get to take him off the first.
+    """
+    skirmish = SkirmishFactory()
+    second_skirmish = SkirmishFactory(player_faction=skirmish.player_faction)
+    captured_warrior = WarriorFactory(faction=skirmish.non_player_faction)
+    skirmish.player_faction.captured_warriors.add(captured_warrior)
+
+    result = handle_warrior_is_captured(
+        context=CaptureWarrior(
+            skirmish=second_skirmish,
+            warrior=captured_warrior,
+            capturing_faction=second_skirmish.non_player_faction,
+        )
+    )
+
+    assert result is None
+    assert list(second_skirmish.non_player_faction.captured_warriors.all()) == []
+
+
+@pytest.mark.django_db
 def test_handle_reduce_warrior_health_kills_the_warrior():
     skirmish = SkirmishFactory()
     attacker = WarriorFactory(faction=skirmish.player_faction)


### PR DESCRIPTION
## The defect

`handle_warrior_is_captured` takes a prisoner unconditionally. That is fine once, but the handler can
run more than once for the same warrior: a warrior may stand on the roster of several unresolved
skirmishes, and `handle_determine_savegame_outcome` force-resolves **every** open skirmish in the
savegame in a single pass when the game ends — not only the fight that ended it.

The result is one warrior with `faction = None` sitting in two different factions' `captured_warriors`
at the same time.

```
FIRST captives : ['Warrior 0']
SECOND captives: ['Warrior 0']
```

Part of #30, and independent of #27 / #29: the repro needs nothing but two overlapping open skirmishes
and the end-of-game resolve, both of which exist on `main` today.

## The fix

One guard: if somebody already holds this warrior, the handler does nothing and returns `None`.

Asked of the captor relation rather than of `warrior.faction is None`, because a missing faction is
also what a *successful* capture leaves behind — reading that would refuse the first capture too.

## Tests

Both fail on `main` and pass with the fix:

- `test_handle_warrior_is_captured_leaves_an_existing_prisoner_where_he_is` — the handler unit.
- `test_a_warrior_in_two_open_fights_is_taken_prisoner_only_once` — the flow test, which is where the
  defect actually lives: the handler is correct on its own and only misbehaves when the force-resolve
  above it calls it a second time. Runs the real queue, no mocking.

## Not fixed here

The other half of #30 — that the same war band can be committed to two fights in one month at all.
Closing that means teaching `exclude_currently_busy()` about `Skirmish.month`, which also collapses
attacking to one attack per month in total, because the leader joins every attack. That is a
game-balance decision rather than a bug fix, so it stays in #30.

## CI

`pre-commit run --all-files` and `uv run pytest --cov` both green, 100% branch coverage held.
