### PR TITLE
Tell the player the game is over instead of doing nothing

### DIFF
--- a/apps/month/tests/test_views.py
+++ b/apps/month/tests/test_views.py
@@ -64,15 +64,20 @@ def test_finish_month_view_lets_a_rival_faction_recover(logged_in_client, curren
 @pytest.mark.django_db
 def test_finish_month_view_refuses_a_finished_savegame(logged_in_client, current_savegame):
     """
-    Covers RunningSavegameRequiredMixin for every view carrying it; which views those are is asserted
-    separately in apps/common/tests/test_ended_savegame_guard.py.
+    Covers the htmx branch of RunningSavegameRequiredMixin; which views carry it at all is asserted
+    separately in apps/common/tests/test_ended_savegame_guard.py, and the full-page branch is covered
+    by the quest accept view, which is one of the two navigations behind the guard.
+
+    The header is what the browser really sends here - base.html drives this button with "hx-post" -
+    and an empty 204 is only the right refusal for a request that can act on one.
     """
     current_savegame.outcome = Savegame.OutcomeChoices.OUTCOME_LOST
     current_savegame.save()
 
-    response = logged_in_client.post(reverse("month:finish-month-view"))
+    response = logged_in_client.post(reverse("month:finish-month-view"), headers={"hx-request": "true"})
 
     assert response.status_code == 204
+    assert json.loads(response["HX-Trigger"]) == {"notification": "This game is over. Start a new savegame to play on."}
     current_savegame.refresh_from_db()
     assert current_savegame.current_month == 1
 

--- a/apps/quest/tests/test_views.py
+++ b/apps/quest/tests/test_views.py
@@ -1,9 +1,11 @@
 import pytest
+from django.contrib.messages import get_messages
 from django.urls import reverse
 
 from apps.faction.tests.factories.faction import FactionFactory
 from apps.quest.models.quest_contract import QuestContract
 from apps.quest.tests.factories.quest import QuestFactory
+from apps.savegame.models.savegame import Savegame
 from apps.savegame.tests.factories.savegame import SavegameFactory
 from apps.skirmish.tests.factories.warrior import WarriorFactory
 
@@ -31,6 +33,27 @@ def test_quest_accept_view_signs_a_contract_and_sets_up_the_skirmish(logged_in_c
     quest_contract = QuestContract.objects.get(quest=quest, faction=current_savegame.player_faction)
     assert list(quest_contract.assigned_warriors.all()) == [warrior]
     assert quest_contract.skirmish is not None
+
+
+@pytest.mark.django_db
+def test_quest_accept_view_sends_the_player_home_on_a_finished_savegame(logged_in_client, current_savegame):
+    """
+    The full-page branch of RunningSavegameRequiredMixin. This is a plain navigation, not an htmx
+    fragment, and a browser handed a 204 abandons the navigation: the page does not change and the
+    player is told nothing. A redirect carrying a warning is the same refusal he can actually see.
+    """
+    quest = QuestFactory(target_faction__savegame=current_savegame)
+    current_savegame.player_faction.available_quests.add(quest)
+    current_savegame.outcome = Savegame.OutcomeChoices.OUTCOME_LOST
+    current_savegame.save()
+
+    response = logged_in_client.get(reverse("quest:quest-accept-view", kwargs={"pk": quest.pk}))
+
+    assert response.status_code == 302
+    assert response.url == reverse("account:dashboard-view")
+    assert [str(message) for message in get_messages(response.wsgi_request)] == [
+        "This game is over. Start a new savegame to play on."
+    ]
 
 
 @pytest.mark.django_db

--- a/apps/savegame/mixins.py
+++ b/apps/savegame/mixins.py
@@ -1,8 +1,10 @@
 import json
 from http import HTTPStatus
 
+from django.contrib import messages
 from django.db.models import QuerySet
-from django.http import HttpResponse
+from django.http import HttpResponse, HttpResponseRedirect
+from django.urls import reverse
 from django.views.generic.base import ContextMixin
 
 from apps.savegame.models.savegame import Savegame
@@ -54,15 +56,27 @@ class RunningSavegameRequiredMixin:
 
     A savegame that is missing entirely is somebody else's problem; the views resolving one already
     answer for that themselves.
+
+    How it refuses depends on who asked. Most of the views behind this are htmx fragments, and an
+    empty 204 carrying a notification is exactly right for them. For the two that are full-page
+    navigations it is not: the browser treats 204 as "nothing to do", abandons the navigation, leaves
+    the player on the page he clicked from and tells him nothing at all. Those get a message and a
+    redirect instead, which is the same toast by another route.
     """
+
+    REFUSAL_NOTICE = "This game is over. Start a new savegame to play on."
 
     def dispatch(self, request, *args, **kwargs) -> HttpResponse:
         current_savegame = Savegame.objects.get_current_savegame(user_id=request.user.id)
 
         if current_savegame is not None and current_savegame.outcome != Savegame.OutcomeChoices.OUTCOME_RUNNING:
-            response = HttpResponse(status=HTTPStatus.NO_CONTENT)
-            response["HX-Trigger"] = json.dumps({"notification": "This game is over. Start a new savegame to play on."})
-            return response
+            if request.headers.get("HX-Request"):
+                response = HttpResponse(status=HTTPStatus.NO_CONTENT)
+                response["HX-Trigger"] = json.dumps({"notification": self.REFUSAL_NOTICE})
+                return response
+
+            messages.add_message(request, messages.WARNING, self.REFUSAL_NOTICE)
+            return HttpResponseRedirect(reverse("account:dashboard-view"))
 
         return super().dispatch(request, *args, **kwargs)
 


### PR DESCRIPTION
## The defect

`RunningSavegameRequiredMixin` refuses a decided savegame with `204 No Content` plus an `HX-Trigger`
notification. That is exactly right for the eight htmx fragments behind it, and wrong for the two
full-page navigations: a browser handed a 204 treats it as "nothing to do", abandons the navigation,
leaves the player on the page he clicked from, and tells him nothing at all. The click simply does
nothing.

Found by a browser walkthrough against a savegame set to `OUTCOME_LOST`: `GET /quest/<id>/accept`
returned 204 and nothing happened on screen.

## The fix

The guard branches on `HX-Request`. htmx keeps today's response byte for byte; anything else gets a
warning message and a redirect to the dashboard, which `base.html` already renders as a toast. One
change at the mixin covers both full-page views and whatever full-page view carries the guard next.

The notice itself moves to a `REFUSAL_NOTICE` attribute so the two branches cannot drift apart.

## Tests

One per branch:

- `test_quest_accept_view_sends_the_player_home_on_a_finished_savegame` covers the new full-page
  branch, through one of the two navigations actually behind the guard. It fails without the change.
- `test_finish_month_view_refuses_a_finished_savegame` covers the htmx branch. It now sends the
  `HX-Request` header, which is what the browser really sends there — `base.html` drives that button
  with `hx-post` — and asserts the 204 plus the trigger payload. To be precise: this one still passes
  against `main`, and cannot fail on a revert, because the htmx path is byte-for-byte unchanged; only
  the header-absent path is new. Updating it was still necessary — left alone it would have started
  failing for the wrong reason, having silently switched to the full-page branch.

`apps/common/tests/test_ended_savegame_guard.py` is untouched: it proves which views carry the mixin,
not what it answers.

## Note on scope

Independent of #29 and #27 — this mixin and both full-page views predate them. #29 adds
`FactionAttackView` as the second full-page view behind the guard, so it benefits from this too, but
neither PR needs the other.

## CI

`pre-commit run --all-files` and `uv run pytest --cov` both green, 100% branch coverage held.
