### PR TITLE
End the fight the perfect defender could not lose

### DIFF
--- a/apps/skirmish/handlers/events/warrior.py
+++ b/apps/skirmish/handlers/events/warrior.py
@@ -1,6 +1,7 @@
 from queuebie import message_registry
 from queuebie.messages import Command
 
+from apps.skirmish.choices.skirmish_action import SkirmishActionChoices
 from apps.skirmish.messages.commands.skirmish import DetermineAttacker
 from apps.skirmish.messages.commands.warrior import (
     CaptureWarrior,
@@ -92,18 +93,41 @@ def handle_experience_gain_on_warrior_incapacitation(
 
 
 @message_registry.register_event(event=warrior.WarriorDefendedAllDamage)
-def handle_morale_increase_on_warriors_defends_all_damage(
-    *, context: warrior.WarriorDefendedAllDamage
-) -> Command | None:
-    increased_morale = round(context.defender.max_morale * 0.1)
+def handle_morale_change_on_warrior_defends_all_damage(*, context: warrior.WarriorDefendedAllDamage) -> Command:
+    """
+    Turning a blow aside steadies a warrior. Cowering behind a shield wears him down.
 
-    if increased_morale > 0:
-        return IncreaseMorale(
+    Without the second half a fight could not end. Below a quarter of his health a warrior always
+    picks a defensive stance, that stance doubles his defense and zeroes his attack, and once the
+    doubled defense outruns what the other side can hit for, nobody takes damage again - and the only
+    other two things that move morale in this game are taking damage and watching a comrade fall.
+    Neither happens, so nobody routs, no side ever loses its last healthy warrior, and the round
+    counter climbs for ever. One observed fight reached 54 rounds. That matters more than it sounds:
+    the month cannot be advanced while a skirmish is unresolved, so such a fight ends the savegame's
+    life rather than its own.
+
+    Draining instead of merely withholding the reward is the whole point - a warrior sitting at the
+    same morale for ever is exactly the fight that never ends. Dropping him to zero raises
+    WarriorHasFled, and a fleeing warrior is not a healthy one, which is what the defeat check in
+    handle_finish_round already counts.
+    """
+    # Ten percent of what he can hold, the same lever the reward and the damage penalty already use.
+    # Floored at one point so the drain cannot round away to nothing on a warrior with little morale
+    # to give - a stance that costs zero is the stalemate all over again.
+    morale_at_stake = max(1, round(context.defender.max_morale * 0.1))
+
+    if context.defender_action == SkirmishActionChoices.DEFENSIVE_STANCE:
+        return ReduceMorale(
             skirmish=context.skirmish,
             warrior=context.defender,
-            increased_morale=increased_morale,
+            lost_morale=morale_at_stake,
         )
-    return None
+
+    return IncreaseMorale(
+        skirmish=context.skirmish,
+        warrior=context.defender,
+        increased_morale=morale_at_stake,
+    )
 
 
 @message_registry.register_event(event=skirmish.SkirmishFinished)

--- a/apps/skirmish/handlers/events/warrior.py
+++ b/apps/skirmish/handlers/events/warrior.py
@@ -93,7 +93,7 @@ def handle_experience_gain_on_warrior_incapacitation(
 
 
 @message_registry.register_event(event=warrior.WarriorDefendedAllDamage)
-def handle_morale_change_on_warrior_defends_all_damage(*, context: warrior.WarriorDefendedAllDamage) -> Command:
+def handle_morale_change_on_warrior_defends_all_damage(*, context: warrior.WarriorDefendedAllDamage) -> Command | None:
     """
     Turning a blow aside steadies a warrior. Cowering behind a shield wears him down.
 
@@ -111,23 +111,28 @@ def handle_morale_change_on_warrior_defends_all_damage(*, context: warrior.Warri
     WarriorHasFled, and a fleeing warrior is not a healthy one, which is what the defeat check in
     handle_finish_round already counts.
     """
-    # Ten percent of what he can hold, the same lever the reward and the damage penalty already use.
-    # Floored at one point so the drain cannot round away to nothing on a warrior with little morale
-    # to give - a stance that costs zero is the stalemate all over again.
-    morale_at_stake = max(1, round(context.defender.max_morale * 0.1))
+    # Ten percent of what he can hold, the lever the reward and the damage penalty already use
+    morale_at_stake = round(context.defender.max_morale * 0.1)
 
     if context.defender_action == SkirmishActionChoices.DEFENSIVE_STANCE:
+        # Floored at one point, and only here: a tenth of a small morale pool rounds away to nothing,
+        # and a stance that costs nothing is the unwinnable fight all over again. The reward keeps its
+        # old shape below, because no such argument applies to it - inventing a point of morale for a
+        # warrior too brittle to have earned one would be a balance change with nothing behind it.
         return ReduceMorale(
             skirmish=context.skirmish,
             warrior=context.defender,
-            lost_morale=morale_at_stake,
+            lost_morale=max(1, morale_at_stake),
         )
 
-    return IncreaseMorale(
-        skirmish=context.skirmish,
-        warrior=context.defender,
-        increased_morale=morale_at_stake,
-    )
+    if morale_at_stake > 0:
+        return IncreaseMorale(
+            skirmish=context.skirmish,
+            warrior=context.defender,
+            increased_morale=morale_at_stake,
+        )
+
+    return None
 
 
 @message_registry.register_event(event=skirmish.SkirmishFinished)

--- a/apps/skirmish/messages/events/warrior.py
+++ b/apps/skirmish/messages/events/warrior.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from queuebie.messages import Event
 
 from apps.faction.models.faction import Faction
+from apps.skirmish.choices.skirmish_action import SkirmishActionTypeHint
 from apps.skirmish.models.skirmish import Skirmish
 from apps.skirmish.models.warrior import Warrior
 
@@ -45,6 +46,9 @@ class WarriorDefendedAllDamage(Event):
     attacker_damage: int
     defender: Warrior
     defender_damage: int
+    # Carried because turning a blow aside and simply standing there behind a shield are worth
+    # opposite things to a warrior's nerve, and the damage alone cannot tell them apart
+    defender_action: SkirmishActionTypeHint
 
 
 @dataclass(kw_only=True)

--- a/apps/skirmish/services/skirmish/damage.py
+++ b/apps/skirmish/services/skirmish/damage.py
@@ -56,6 +56,7 @@ class SkirmishDamageService:
                     defender=self.defender,
                     attacker_damage=attack,
                     defender_damage=defense,
+                    defender_action=self.defender_action,
                 )
             )
 

--- a/apps/skirmish/tests/handlers/events/test_battle_history.py
+++ b/apps/skirmish/tests/handlers/events/test_battle_history.py
@@ -70,6 +70,7 @@ def test_handle_log_warrior_defends_all_damage_logs_the_successful_defense():
             attacker_damage=2,
             defender=defender,
             defender_damage=7,
+            defender_action=SkirmishActionChoices.SIMPLE_ATTACK,
         )
     )
 

--- a/apps/skirmish/tests/handlers/events/test_warrior.py
+++ b/apps/skirmish/tests/handlers/events/test_warrior.py
@@ -163,6 +163,31 @@ def test_handle_morale_change_on_warrior_defends_all_damage_wears_down_a_turtle(
 
 
 @pytest.mark.django_db
+def test_handle_morale_change_on_warrior_defends_all_damage_rewards_nothing_on_a_tiny_morale_pool():
+    """
+    The floor below applies to the drain only. A tenth of a small pool still rounds to nothing on the
+    reward side, exactly as it did before there was a drain at all - a warrior too brittle to earn a
+    point of morale is not handed one.
+    """
+    skirmish = SkirmishFactory()
+    attacker = WarriorFactory(faction=skirmish.player_faction)
+    defender = WarriorFactory(faction=skirmish.non_player_faction, current_morale=4, max_morale=4)
+
+    result = handle_morale_change_on_warrior_defends_all_damage(
+        context=WarriorDefendedAllDamage(
+            skirmish=skirmish,
+            attacker=attacker,
+            attacker_damage=5,
+            defender=defender,
+            defender_damage=5,
+            defender_action=SkirmishActionChoices.SIMPLE_ATTACK,
+        )
+    )
+
+    assert result is None
+
+
+@pytest.mark.django_db
 def test_handle_morale_change_on_warrior_defends_all_damage_always_costs_at_least_a_point():
     """
     A tenth of a small morale pool rounds to nothing, and a stance that costs nothing is the

--- a/apps/skirmish/tests/handlers/events/test_warrior.py
+++ b/apps/skirmish/tests/handlers/events/test_warrior.py
@@ -1,11 +1,12 @@
 import pytest
 
+from apps.skirmish.choices.skirmish_action import SkirmishActionChoices
 from apps.skirmish.handlers.events.warrior import (
     handle_capture_unconscious_warriors,
     handle_experience_gain_after_battle_for_victor,
     handle_experience_gain_on_warrior_incapacitation,
+    handle_morale_change_on_warrior_defends_all_damage,
     handle_morale_drop_on_faction_on_warrior_is_out_of_fight,
-    handle_morale_increase_on_warriors_defends_all_damage,
     handle_reduce_health_and_update_condition,
 )
 from apps.skirmish.messages.commands.warrior import (
@@ -118,18 +119,19 @@ def test_handle_experience_gain_on_warrior_incapacitation_for_a_killed_warrior()
 
 
 @pytest.mark.django_db
-def test_handle_morale_increase_on_warriors_defends_all_damage_rewards_the_defender():
+def test_handle_morale_change_on_warrior_defends_all_damage_rewards_a_real_defence():
     skirmish = SkirmishFactory()
     attacker = WarriorFactory(faction=skirmish.player_faction)
     defender = WarriorFactory(faction=skirmish.non_player_faction, current_morale=10, max_morale=20)
 
-    result = handle_morale_increase_on_warriors_defends_all_damage(
+    result = handle_morale_change_on_warrior_defends_all_damage(
         context=WarriorDefendedAllDamage(
             skirmish=skirmish,
             attacker=attacker,
             attacker_damage=5,
             defender=defender,
             defender_damage=5,
+            defender_action=SkirmishActionChoices.SIMPLE_ATTACK,
         )
     )
 
@@ -137,22 +139,51 @@ def test_handle_morale_increase_on_warriors_defends_all_damage_rewards_the_defen
 
 
 @pytest.mark.django_db
-def test_handle_morale_increase_on_warriors_defends_all_damage_rewards_nothing_on_a_tiny_morale_pool():
+def test_handle_morale_change_on_warrior_defends_all_damage_wears_down_a_turtle():
+    """
+    Standing behind a shield is what makes a fight unwinnable, so it costs nerve instead of building
+    it - otherwise nothing moves the morale of a warrior nobody can hurt.
+    """
     skirmish = SkirmishFactory()
     attacker = WarriorFactory(faction=skirmish.player_faction)
-    defender = WarriorFactory(faction=skirmish.non_player_faction, current_morale=4, max_morale=4)
+    defender = WarriorFactory(faction=skirmish.non_player_faction, current_morale=10, max_morale=20)
 
-    result = handle_morale_increase_on_warriors_defends_all_damage(
+    result = handle_morale_change_on_warrior_defends_all_damage(
         context=WarriorDefendedAllDamage(
             skirmish=skirmish,
             attacker=attacker,
             attacker_damage=5,
             defender=defender,
             defender_damage=5,
+            defender_action=SkirmishActionChoices.DEFENSIVE_STANCE,
         )
     )
 
-    assert result is None
+    assert result == ReduceMorale(skirmish=skirmish, warrior=defender, lost_morale=2)
+
+
+@pytest.mark.django_db
+def test_handle_morale_change_on_warrior_defends_all_damage_always_costs_at_least_a_point():
+    """
+    A tenth of a small morale pool rounds to nothing, and a stance that costs nothing is the
+    unwinnable fight all over again.
+    """
+    skirmish = SkirmishFactory()
+    attacker = WarriorFactory(faction=skirmish.player_faction)
+    defender = WarriorFactory(faction=skirmish.non_player_faction, current_morale=4, max_morale=4)
+
+    result = handle_morale_change_on_warrior_defends_all_damage(
+        context=WarriorDefendedAllDamage(
+            skirmish=skirmish,
+            attacker=attacker,
+            attacker_damage=5,
+            defender=defender,
+            defender_damage=5,
+            defender_action=SkirmishActionChoices.DEFENSIVE_STANCE,
+        )
+    )
+
+    assert result == ReduceMorale(skirmish=skirmish, warrior=defender, lost_morale=1)
 
 
 @pytest.mark.django_db

--- a/apps/skirmish/tests/services/skirmish/test_damage.py
+++ b/apps/skirmish/tests/services/skirmish/test_damage.py
@@ -47,5 +47,8 @@ def test_deal_damage_announces_a_fully_defended_attack(damage_service):
             defender=damage_service.defender,
             attacker_damage=2,
             defender_damage=7,
+            # Passed on because whether the defender was turtling decides what the block does to his
+            # nerve, and only the service knows which action he picked
+            defender_action=damage_service.defender_action,
         )
     ]

--- a/apps/skirmish/tests/test_flows.py
+++ b/apps/skirmish/tests/test_flows.py
@@ -1,0 +1,45 @@
+import pytest
+from queuebie.runner import handle_message
+
+from apps.skirmish.choices.skirmish_action import SkirmishActionChoices
+from apps.skirmish.messages.events.warrior import WarriorDefendedAllDamage
+from apps.skirmish.models.warrior import Warrior
+from apps.skirmish.tests.factories.skirmish import SkirmishFactory
+from apps.skirmish.tests.factories.warrior import WarriorFactory
+
+
+@pytest.mark.django_db
+def test_a_warrior_who_only_turtles_eventually_routs(queuebie_registry):
+    """
+    The chain that makes an unwinnable fight end, run for real rather than asserted handler by handler.
+
+    Below a quarter of his health a warrior always picks a defensive stance, which doubles his defense
+    and zeroes his attack. Once that defense outruns what the other side can hit for, nobody takes
+    damage and nobody falls - and those were the only two things that moved morale. So the drain has
+    to come from the stance itself, and it has to reach all the way to CONDITION_FLEEING, which the
+    defeat check counts as "not healthy". Only a real queue run proves the three handlers between the
+    block and the rout are actually wired to each other.
+
+    Set one round short of routing rather than looped: what matters is that the last point of morale
+    turns into a rout, not how many rounds it took to get there.
+    """
+    skirmish = SkirmishFactory()
+    attacker = WarriorFactory(faction=skirmish.player_faction)
+    exhausted_defender = WarriorFactory(
+        faction=skirmish.non_player_faction, current_morale=2, max_morale=20, current_health=3
+    )
+
+    handle_message(
+        WarriorDefendedAllDamage(
+            skirmish=skirmish,
+            attacker=attacker,
+            attacker_damage=4,
+            defender=exhausted_defender,
+            defender_damage=20,
+            defender_action=SkirmishActionChoices.DEFENSIVE_STANCE,
+        )
+    )
+
+    exhausted_defender.refresh_from_db()
+    assert exhausted_defender.current_morale == 0
+    assert exhausted_defender.condition == Warrior.ConditionChoices.CONDITION_FLEEING


### PR DESCRIPTION
## The defect

A fight can reach a state nobody can win, and it is deterministic rather than bad luck:

```
defender under 25% max health   → DEFENSIVE_STANCE, every round
                                  SkirmishActionDecisionService._determine_decision
defensive stance                → attack 0, defense doubled
                                  DefensiveStanceService
defended all damage             → +10% morale
                                  handle_morale_increase_on_warriors_defends_all_damage
victor declared                 → only when one side has no CONDITION_HEALTHY warrior
                                  handle_finish_round
```

Once the doubled defense outruns what the attacker can hit for, nobody takes damage, nobody falls,
nobody routs, and there is no round cap. One observed fight reached 54 rounds with the defender
*gaining* morale each one. A dying enemy is the hardest to kill.

It costs more than the fight: `apps/month/views.py:27` refuses to advance the month while any skirmish
is unresolved, so a stalemate leaves the savegame with no legal move at all. Getting a browser
walkthrough past it needed `victorious_faction` written into the database by hand.

Pre-existing on `main` and independent of #27 / #29.

## Why "stop gaining morale" is not the fix

The obvious fix — drop the +10% reward — does **not** work, and this is worth spelling out because it
is the version that was first proposed. There are exactly three things that move morale:

| Change | Fires in a stalemate? |
|---|---|
| −10% on taking damage | no, damage is 0 |
| −10% when a comrade falls or flees | no, nobody falls |
| +10% on defending all damage | yes, every round |

Remove the third and *nothing* moves morale: it sits still for ever and the fight is still unwinnable.
Withholding the reward is not the same as applying a cost.

## The fix

A defensive stance **drains** 10% of max morale per round instead of granting it. Turning a blow aside
still steadies a warrior; standing there behind a shield wears him down. Driving morale to zero raises
`WarriorHasFled`, and a fleeing warrior is not a healthy one — which the defeat check in
`handle_finish_round` already counts, so no new resolution path is needed.

`WarriorDefendedAllDamage` gains `defender_action`, because the damage alone cannot tell a block from a
cower and only the damage service knows which action was picked.

The drain is floored at one point. A tenth of a small morale pool rounds to zero, and a stance that
costs nothing is the same unwinnable fight.

The floor applies to the **drain only**. A first cut computed it before the branch, which quietly
floored the reward too and handed +1 morale to a warrior with `max_morale=4` where the old code gave
nothing — caught in review, and the deleted test covering that case is restored. The reward keeps its
original shape, because no termination argument applies to it.

10% mirrors the lever the reward and the damage penalty already use, so a warrior at full morale routs
in about ten rounds of turtling. The number sits inline beside the other two combat percentages rather
than in `apps/town/buildings/`, whose rule covers building costs and effects.

## Tests

- the handler, both branches, plus the floor at one point
- `apps/skirmish/tests/test_flows.py` — a real queue run proving a nearly-spent turtle actually reaches
  `CONDITION_FLEEING`, which is the part no unit test can show: three handlers sit between the block
  and the rout and only the registry connects them

## Out of scope

A player withdrawal action (its own story — command, event, handlers, template, tests) and a round cap
that auto-resolves (arbitrary, and it would hide balance problems instead of surfacing them).

## CI

`pre-commit run --all-files` and `uv run pytest --cov` both green, 100% branch coverage held.
