### PR TITLE
Say which culture is missing instead of dying on it

### DIFF
--- a/apps/faction/handlers/commands/faction.py
+++ b/apps/faction/handlers/commands/faction.py
@@ -48,6 +48,16 @@ def handle_create_factions_for_new_savegame(*, context: CreateFactionsForNewSave
     emitting it runs under strict mode's database blocker.
     """
     culture = Culture.objects.get_or_none(id=context.faction_culture_id)
+    # Cultures are reference data, and a database missing them used to die one line down on
+    # "NoneType has no attribute locale". Says what is missing instead, the way the item generator
+    # already does for its own fixture. This guards the rival draw below as well: a culture coming
+    # back here is proof the table has rows for "random.choice" to pick from.
+    if culture is None:
+        raise RuntimeError(
+            f"Culture {context.faction_culture_id} does not exist. "
+            f"Load the reference data with 'loaddata culture itemtype'."
+        )
+
     faker = Faker([culture.locale])
 
     return [

--- a/apps/faction/tests/handlers/commands/test_faction.py
+++ b/apps/faction/tests/handlers/commands/test_faction.py
@@ -33,6 +33,7 @@ from apps.faction.messages.events.faction import (
     QuestWasRemovedFromBulletinBoard,
     RequestNewItemForTownShop,
 )
+from apps.faction.models.culture import Culture
 from apps.faction.models.faction import Faction
 from apps.faction.tests.factories.culture import CultureFactory
 from apps.faction.tests.factories.faction import FactionFactory
@@ -353,6 +354,31 @@ def test_handle_create_factions_for_new_savegame_adds_the_drawn_number_of_rival_
     # Rival factions get a generated town of their own instead of the player's
     assert result[3].town_name != ""
     assert result[3].town_name != "Winchester"
+
+
+@pytest.mark.django_db
+def test_handle_create_factions_for_new_savegame_without_the_culture():
+    """
+    Cultures are reference data every environment ships with, so a missing one is a half-seeded
+    database rather than bad input - and it used to surface one line later as "NoneType has no
+    attribute locale".
+
+    A culture id nobody owns rather than an emptied table: the fixtures are loaded once per session,
+    and this is the path the crash actually arrives by, since a database without them renders the
+    dropdown empty and cannot be submitted at all.
+    """
+    savegame = SavegameFactory()
+    missing_culture_id = Culture.objects.order_by("-id").first().id + 1
+
+    with pytest.raises(RuntimeError, match=f"Culture {missing_culture_id} does not exist"):
+        handle_create_factions_for_new_savegame(
+            context=CreateFactionsForNewSavegame(
+                savegame=savegame,
+                faction_name="Wessex",
+                town_name="Winchester",
+                faction_culture_id=missing_culture_id,
+            )
+        )
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## The defect

Bootstrapping a savegame against a database without the `culture` fixture died on
`AttributeError: 'NoneType' object has no attribute 'locale'`, one line after the lookup that was
already prepared to return `None`:

```python
culture = Culture.objects.get_or_none(id=context.faction_culture_id)
faker = Faker([culture.locale])
```

Closes #32.

## The fix

A guard that names what is missing, in the spirit of the two in `QuestGenerator.process()`:

```python
if culture is None:
    raise RuntimeError(
        f"Culture {context.faction_culture_id} does not exist. "
        f"Load the reference data with 'loaddata culture itemtype'."
    )
```

This is the promise `docs/patterns/testing-data.md` already makes on behalf of the reference data —
that a database missing it "raises `RuntimeError` during generation". `ItemType` keeps it in
`BaseItemGenerator.process()`; `Culture` now does too.

`get_or_none` stays. It is not pointless once something reads the `None` it exists to return, and
swapping it for `.get()` would trade one unhelpful exception for another.

**One guard covers both reads of the table.** The handler also draws `random.choice(Culture.objects.all())`
for each rival, which would raise `IndexError` on an empty table. A culture coming back from the
lookup above is proof the table has rows, so that draw cannot be reached with nothing to draw from.

## Test

One test, beside the handler's existing two. It passes a culture id nobody owns rather than emptying
the table: the root `conftest.py` loads both fixtures once per session, and `testing-data.md` is
explicit that a test must not assume the reference tables are empty. It is also the path the crash
actually arrives by — on a virgin database the culture dropdown renders empty, so the form cannot be
submitted at all and the id has to be posted directly.

Reverting the guard makes it fail with the exact `AttributeError` from the issue, which is how the
reproduction was confirmed rather than assumed.

## Correction: this guards a path the web UI cannot reach

Driven in a browser against a virgin database (`migrate`, no `loaddata`), and the issue's reachability
claim does not hold. Posting a culture id directly to `/savegame/create/` does **not** reach the
handler — `faction_culture` is a `ModelChoiceField(queryset=Culture.objects.all())`, so an id with no
row behind it is rejected by form validation with *"Select a valid choice. That choice is not one of
the available choices."*, HTTP 200, handler never called. The view then passes
`form.cleaned_data["faction_culture"].id`, an already-validated instance, and the sole emitter of
`CreateFactionsForNewSavegame` is the event handler carrying that value. So the `AttributeError` was
not reachable through the UI at all.

That does not make the guard pointless, but it does change what it is for. It is defence in depth on a
bus command, in the same spirit as the empty-roster check added to `BaseSkirmishGenerator` in #29: the
trap is at handler level, the view guarding it is not the handler's business, and every future emitter
would otherwise have to remember. It also makes `Culture` honour the promise
`docs/patterns/testing-data.md` already makes on behalf of the reference data.

Verified the guard does fire where the handler *is* reachable — dispatching
`CreateFactionsForNewSavegame` with a missing id through the real bus gives:

```
RuntimeError: Culture 99 does not exist. Load the reference data with 'loaddata culture itemtype'.
```

And no regression on the happy path: with the fixtures loaded, creating a savegame through the form
bootstraps the player faction plus four rivals, each with a leader.

## Out of scope

Everything the issue rules out: the fixtures match the development database, nothing needs rescuing,
and there is no case for promoting them to a data migration.

Also named and not done: on a virgin database the culture dropdown renders **empty**, so the
create-savegame page looks fine and simply cannot be submitted. Same missing precondition, but a
form-level question rather than this crash.

## CI

`pre-commit run --all-files` and `uv run pytest --cov` both green on the first round — 522 tests,
100% branch coverage.

## Review coverage

One sharded review at `4744056`, complete inside the deadline: **no findings** at or above the
confidence bar. Four specific claims were put to it and all four were refuted with reasons — that one
guard really covers both reads of the culture table, that `RuntimeError` matches the precedent, that
the test genuinely fails without the guard (verified by reverting it, not by reading), and that
`get_or_none` is still the right call now that something reads its result.

**Lenses 02–04 were not run as separate shards** — a 36-line diff sits in the one-shard band, so the
ranked lenses below the first are dropped by design. Their subject matter was folded into the single
shard's brief, which was told to check test honesty, the reference-data conventions in
`testing-data.md`, and conformance to the issue. What nothing looked for on its own is duplication
that could have been reused, which on a two-file one-guard change is close to vacuous.

## Scheduling note

#32 carries an owner comment asking that it not be scheduled on its own, but picked up alongside the
next change touching the savegame bootstrap or the culture reference data. This was raised before any
code was written and then explicitly approved, so it is recorded here rather than silently overridden.
