### PR TITLE
Skirmish sides named for their role, not for the player

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@ htmlcov/
 
 # Scratch state for the /implement-story skill: specs, plans, CI logs and review shards.
 .claude/runs/
+
+# Git worktrees the agent skills check out inside the repo. Registered worktrees are still untracked
+# content here, so without this a nested checkout of the project can be committed by accident.
+.claude/worktrees/

--- a/apps/account/tests/test_views.py
+++ b/apps/account/tests/test_views.py
@@ -113,7 +113,7 @@ def test_dashboard_view_lists_the_month_logs_of_the_current_savegame(logged_in_c
 
 @pytest.mark.django_db
 def test_dashboard_view_shows_an_active_quest_with_a_skirmish(logged_in_client, current_savegame):
-    skirmish = SkirmishFactory(player_faction=current_savegame.player_faction)
+    skirmish = SkirmishFactory(attacking_faction=current_savegame.player_faction)
     quest_contract = QuestContractFactory(faction=current_savegame.player_faction, skirmish=skirmish)
     current_savegame.player_faction.active_quests.add(quest_contract)
 

--- a/apps/faction/tests/handlers/commands/test_faction.py
+++ b/apps/faction/tests/handlers/commands/test_faction.py
@@ -70,7 +70,7 @@ def test_handle_create_new_faction_for_player_faction():
 
 
 @pytest.mark.django_db
-def test_handle_create_new_faction_for_non_player_faction():
+def test_handle_create_new_faction_for_defending_faction():
     savegame = SavegameFactory(current_month=5)
     culture = CultureFactory()
 

--- a/apps/faction/tests/managers/test_faction.py
+++ b/apps/faction/tests/managers/test_faction.py
@@ -120,12 +120,12 @@ def test_attackable_by_offers_nobody_once_the_war_band_has_marched(player_factio
     untouched_faction = FactionFactory(savegame=player_faction.savegame)
     WarriorFactory(faction=untouched_faction)
     skirmish = SkirmishFactory(
-        player_faction=player_faction,
-        non_player_faction=rival_faction,
+        attacking_faction=player_faction,
+        defending_faction=rival_faction,
         victorious_faction=player_faction,
         month=3,
     )
-    skirmish.player_warriors.add(player_faction.leader)
+    skirmish.attacking_warriors.add(player_faction.leader)
 
     result = Faction.objects.attackable_by(player_faction=player_faction, month=3)
 
@@ -137,12 +137,12 @@ def test_attackable_by_offers_a_rival_again_the_month_after(player_faction):
     rival_faction = FactionFactory(savegame=player_faction.savegame)
     WarriorFactory(faction=rival_faction)
     skirmish = SkirmishFactory(
-        player_faction=player_faction,
-        non_player_faction=rival_faction,
+        attacking_faction=player_faction,
+        defending_faction=rival_faction,
         victorious_faction=player_faction,
         month=2,
     )
-    skirmish.player_warriors.add(player_faction.leader)
+    skirmish.attacking_warriors.add(player_faction.leader)
 
     result = Faction.objects.attackable_by(player_faction=player_faction, month=3)
 
@@ -157,8 +157,8 @@ def test_attackable_by_offers_nobody_while_a_fight_is_still_undecided(player_fac
     """
     rival_faction = FactionFactory(savegame=player_faction.savegame)
     WarriorFactory(faction=rival_faction)
-    skirmish = SkirmishFactory(player_faction=player_faction, non_player_faction=rival_faction, month=2)
-    skirmish.player_warriors.add(player_faction.leader)
+    skirmish = SkirmishFactory(attacking_faction=player_faction, defending_faction=rival_faction, month=2)
+    skirmish.attacking_warriors.add(player_faction.leader)
 
     result = Faction.objects.attackable_by(player_faction=player_faction, month=3)
 

--- a/apps/faction/tests/models/test_faction.py
+++ b/apps/faction/tests/models/test_faction.py
@@ -46,8 +46,8 @@ def test_has_marched_this_month_after_a_fight():
     faction = FactionFactory()
     faction.leader = WarriorFactory(faction=faction)
     faction.save()
-    skirmish = SkirmishFactory(player_faction=faction, victorious_faction=faction, month=3)
-    skirmish.player_warriors.add(faction.leader)
+    skirmish = SkirmishFactory(attacking_faction=faction, victorious_faction=faction, month=3)
+    skirmish.attacking_warriors.add(faction.leader)
 
     result = faction.has_marched_this_month(month=3)
 

--- a/apps/faction/tests/test_views.py
+++ b/apps/faction/tests/test_views.py
@@ -88,12 +88,12 @@ def test_faction_detail_view_says_why_the_attack_is_gone(
     rival_faction = FactionFactory(savegame=current_savegame)
     WarriorFactory(faction=rival_faction)
     skirmish = SkirmishFactory(
-        player_faction=player_faction_ready_to_march,
-        non_player_faction=rival_faction,
+        attacking_faction=player_faction_ready_to_march,
+        defending_faction=rival_faction,
         victorious_faction=player_faction_ready_to_march,
         month=current_savegame.current_month,
     )
-    skirmish.player_warriors.add(player_faction_ready_to_march.leader)
+    skirmish.attacking_warriors.add(player_faction_ready_to_march.leader)
 
     response = logged_in_client.get(reverse("faction:faction-detail-view", kwargs={"pk": rival_faction.id}))
 
@@ -110,12 +110,12 @@ def test_faction_detail_view_says_nothing_about_marching_on_the_players_own_fact
     button is missing - it was never on offer.
     """
     skirmish = SkirmishFactory(
-        player_faction=player_faction_ready_to_march,
-        non_player_faction=FactionFactory(savegame=current_savegame),
+        attacking_faction=player_faction_ready_to_march,
+        defending_faction=FactionFactory(savegame=current_savegame),
         victorious_faction=player_faction_ready_to_march,
         month=current_savegame.current_month,
     )
-    skirmish.player_warriors.add(player_faction_ready_to_march.leader)
+    skirmish.attacking_warriors.add(player_faction_ready_to_march.leader)
 
     response = logged_in_client.get(
         reverse("faction:faction-detail-view", kwargs={"pk": player_faction_ready_to_march.id})
@@ -135,12 +135,12 @@ def test_faction_detail_view_says_nothing_about_marching_on_a_defeated_faction(
     defeated_faction = FactionFactory(savegame=current_savegame, is_defeated=True)
     WarriorFactory(faction=defeated_faction)
     skirmish = SkirmishFactory(
-        player_faction=player_faction_ready_to_march,
-        non_player_faction=defeated_faction,
+        attacking_faction=player_faction_ready_to_march,
+        defending_faction=defeated_faction,
         victorious_faction=player_faction_ready_to_march,
         month=current_savegame.current_month,
     )
-    skirmish.player_warriors.add(player_faction_ready_to_march.leader)
+    skirmish.attacking_warriors.add(player_faction_ready_to_march.leader)
 
     response = logged_in_client.get(reverse("faction:faction-detail-view", kwargs={"pk": defeated_faction.id}))
 
@@ -314,9 +314,9 @@ def test_faction_attack_view_fights_the_rivals_own_war_band(
     assert [str(message) for message in get_messages(response.wsgi_request)] == [
         f"Your war band marches on {rival_faction}."
     ]
-    skirmish = Skirmish.objects.get(non_player_faction=rival_faction)
-    assert list(skirmish.non_player_warriors.all()) == [rival_leader]
-    assert list(skirmish.player_warriors.all()) == [player_faction_ready_to_march.leader, follower]
+    skirmish = Skirmish.objects.get(defending_faction=rival_faction)
+    assert list(skirmish.defending_warriors.all()) == [rival_leader]
+    assert list(skirmish.attacking_warriors.all()) == [player_faction_ready_to_march.leader, follower]
     assert skirmish.month == current_savegame.current_month
 
 
@@ -378,12 +378,12 @@ def test_faction_attack_view_cannot_march_twice_in_a_month(
     """
     already_fought = FactionFactory(savegame=current_savegame)
     fought_skirmish = SkirmishFactory(
-        player_faction=player_faction_ready_to_march,
-        non_player_faction=already_fought,
+        attacking_faction=player_faction_ready_to_march,
+        defending_faction=already_fought,
         victorious_faction=player_faction_ready_to_march,
         month=current_savegame.current_month,
     )
-    fought_skirmish.player_warriors.add(player_faction_ready_to_march.leader)
+    fought_skirmish.attacking_warriors.add(player_faction_ready_to_march.leader)
     untouched_rival = FactionFactory(savegame=current_savegame)
     WarriorFactory(faction=untouched_rival)
 

--- a/apps/month/tests/test_views.py
+++ b/apps/month/tests/test_views.py
@@ -84,7 +84,7 @@ def test_finish_month_view_refuses_a_finished_savegame(logged_in_client, current
 
 @pytest.mark.django_db
 def test_finish_month_view_keeps_the_month_open_while_a_skirmish_is_unresolved(logged_in_client, current_savegame):
-    SkirmishFactory(player_faction=current_savegame.player_faction)
+    SkirmishFactory(attacking_faction=current_savegame.player_faction)
 
     response = logged_in_client.post(reverse("month:finish-month-view"))
 

--- a/apps/quest/handlers/commands/quest_contract.py
+++ b/apps/quest/handlers/commands/quest_contract.py
@@ -16,6 +16,13 @@ def handle_assign_skirmish_to_quest_contract(*, context: AssignSkirmishToQuestCo
 
 @message_registry.register_command(command=RemoveQuestContractAsActiveQuest)
 def handle_remove_quest_contract_as_active_quest(*, context: RemoveQuestContractAsActiveQuest) -> Event:
-    context.faction.active_quests.remove(context.quest_contract)
+    # The contract's own faction, asked here rather than carried on the command. The caller used to
+    # hand in the skirmish's attacking side, which is only the signatory because the faction that
+    # accepts a quest is also the one that marches: clearing the active quest of a faction that never
+    # signed it is a silent no-op, so the real holder kept a finished quest forever. Reading the
+    # relation is a query, which is why it happens in this command handler and not in the event
+    # handler that raises the command.
+    faction = context.quest_contract.faction
+    faction.active_quests.remove(context.quest_contract)
 
-    return QuestContractAsActiveQuestRemoved(quest_contract=context.quest_contract, faction=context.faction)
+    return QuestContractAsActiveQuestRemoved(quest_contract=context.quest_contract, faction=faction)

--- a/apps/quest/handlers/events/quest_contract.py
+++ b/apps/quest/handlers/events/quest_contract.py
@@ -24,4 +24,4 @@ def handle_finish_quest_contract(*, context: skirmish.SkirmishFinished) -> Comma
         # There might be skirmishes with no assigned quest contract
         return None
 
-    return RemoveQuestContractAsActiveQuest(quest_contract=quest_contract, faction=context.skirmish.player_faction)
+    return RemoveQuestContractAsActiveQuest(quest_contract=quest_contract, faction=context.skirmish.attacking_faction)

--- a/apps/quest/handlers/events/quest_contract.py
+++ b/apps/quest/handlers/events/quest_contract.py
@@ -24,4 +24,4 @@ def handle_finish_quest_contract(*, context: skirmish.SkirmishFinished) -> Comma
         # There might be skirmishes with no assigned quest contract
         return None
 
-    return RemoveQuestContractAsActiveQuest(quest_contract=quest_contract, faction=context.skirmish.attacking_faction)
+    return RemoveQuestContractAsActiveQuest(quest_contract=quest_contract)

--- a/apps/quest/messages/commands/quest_contract.py
+++ b/apps/quest/messages/commands/quest_contract.py
@@ -2,7 +2,6 @@ from dataclasses import dataclass
 
 from queuebie.messages import Command
 
-from apps.faction.models import Faction
 from apps.quest.models import QuestContract
 from apps.skirmish.models import Skirmish
 
@@ -15,5 +14,6 @@ class AssignSkirmishToQuestContract(Command):
 
 @dataclass(kw_only=True)
 class RemoveQuestContractAsActiveQuest(Command):
+    # No faction: the contract records the faction that signed it, and carrying a second one alongside
+    # it let the two disagree - see handle_remove_quest_contract_as_active_quest
     quest_contract: QuestContract
-    faction: Faction

--- a/apps/quest/tests/forms/test_quest_accept.py
+++ b/apps/quest/tests/forms/test_quest_accept.py
@@ -20,8 +20,8 @@ def test_assignable_warriors_exclude_a_warrior_still_in_last_month_s_fight():
     committed_warrior = WarriorFactory(faction=faction)
     old_contract = QuestContractFactory(faction=faction, accepted_in_month=1)
     old_contract.assigned_warriors.add(committed_warrior)
-    open_skirmish = SkirmishFactory(player_faction=faction, month=1)
-    open_skirmish.player_warriors.add(committed_warrior)
+    open_skirmish = SkirmishFactory(attacking_faction=faction, month=1)
+    open_skirmish.attacking_warriors.add(committed_warrior)
 
     new_quest = QuestFactory(target_faction__savegame=savegame)
     form = QuestAcceptForm(quest_id=new_quest.id, player_faction_id=faction.id)

--- a/apps/quest/tests/handlers/commands/test_quest_contract.py
+++ b/apps/quest/tests/handlers/commands/test_quest_contract.py
@@ -17,7 +17,7 @@ def test_handle_assign_skirmish_to_quest_contract_stores_the_link():
     notice it regressing - and that one would blame the view rather than the handler.
     """
     skirmish = SkirmishFactory()
-    quest_contract = QuestContractFactory(faction=skirmish.player_faction)
+    quest_contract = QuestContractFactory(faction=skirmish.attacking_faction)
 
     result = handle_assign_skirmish_to_quest_contract(
         context=AssignSkirmishToQuestContract(quest_contract=quest_contract, skirmish=skirmish)

--- a/apps/quest/tests/handlers/commands/test_quest_contract.py
+++ b/apps/quest/tests/handlers/commands/test_quest_contract.py
@@ -1,5 +1,6 @@
 import pytest
 
+from apps.faction.tests.factories.faction import FactionFactory
 from apps.quest.handlers.commands.quest_contract import (
     handle_assign_skirmish_to_quest_contract,
     handle_remove_quest_contract_as_active_quest,
@@ -35,8 +36,31 @@ def test_handle_remove_quest_contract_as_active_quest_takes_it_off_the_faction()
     faction.active_quests.add(quest_contract)
 
     result = handle_remove_quest_contract_as_active_quest(
-        context=RemoveQuestContractAsActiveQuest(quest_contract=quest_contract, faction=faction)
+        context=RemoveQuestContractAsActiveQuest(quest_contract=quest_contract)
     )
 
     assert result == QuestContractAsActiveQuestRemoved(quest_contract=quest_contract, faction=faction)
     assert list(faction.active_quests.all()) == []
+
+
+@pytest.mark.django_db
+def test_handle_remove_quest_contract_as_active_quest_ignores_who_else_was_in_the_fight():
+    """
+    The signatory is the only faction that can hold the contract as an active quest.
+
+    The command used to carry a faction of its own, filled with the skirmish's attacking side, and
+    clearing the active quest of a faction that never signed is a silent no-op - so the holder kept a
+    finished quest forever the moment the two came apart.
+    """
+    quest_contract = QuestContractFactory()
+    signatory = quest_contract.faction
+    signatory.active_quests.add(quest_contract)
+    other_faction = FactionFactory(savegame=signatory.savegame)
+    other_faction.active_quests.add(quest_contract)
+
+    result = handle_remove_quest_contract_as_active_quest(
+        context=RemoveQuestContractAsActiveQuest(quest_contract=quest_contract)
+    )
+
+    assert result == QuestContractAsActiveQuestRemoved(quest_contract=quest_contract, faction=signatory)
+    assert list(signatory.active_quests.all()) == []

--- a/apps/quest/tests/handlers/events/test_quest_contract.py
+++ b/apps/quest/tests/handlers/events/test_quest_contract.py
@@ -48,7 +48,7 @@ def test_handle_finish_quest_contract_closes_the_contract_behind_the_skirmish():
         )
     )
 
-    assert result == RemoveQuestContractAsActiveQuest(quest_contract=quest_contract, faction=skirmish.attacking_faction)
+    assert result == RemoveQuestContractAsActiveQuest(quest_contract=quest_contract)
 
 
 @pytest.mark.django_db

--- a/apps/quest/tests/handlers/events/test_quest_contract.py
+++ b/apps/quest/tests/handlers/events/test_quest_contract.py
@@ -13,7 +13,7 @@ from apps.skirmish.tests.factories.skirmish import SkirmishFactory
 @pytest.mark.django_db
 def test_handle_link_quest_contract_to_its_skirmish_assigns_the_contract():
     skirmish = SkirmishFactory()
-    quest_contract = QuestContractFactory(faction=skirmish.player_faction)
+    quest_contract = QuestContractFactory(faction=skirmish.attacking_faction)
 
     result = handle_link_quest_contract_to_its_skirmish(
         context=SkirmishCreated(skirmish=skirmish, quest_contract=quest_contract)
@@ -34,7 +34,7 @@ def test_handle_link_quest_contract_to_its_skirmish_stays_silent_without_a_contr
 @pytest.mark.django_db
 def test_handle_finish_quest_contract_closes_the_contract_behind_the_skirmish():
     skirmish = SkirmishFactory()
-    quest_contract = QuestContractFactory(faction=skirmish.player_faction, skirmish=skirmish)
+    quest_contract = QuestContractFactory(faction=skirmish.attacking_faction, skirmish=skirmish)
 
     result = handle_finish_quest_contract(
         context=SkirmishFinished(
@@ -48,7 +48,7 @@ def test_handle_finish_quest_contract_closes_the_contract_behind_the_skirmish():
         )
     )
 
-    assert result == RemoveQuestContractAsActiveQuest(quest_contract=quest_contract, faction=skirmish.player_faction)
+    assert result == RemoveQuestContractAsActiveQuest(quest_contract=quest_contract, faction=skirmish.attacking_faction)
 
 
 @pytest.mark.django_db

--- a/apps/savegame/handlers/commands/savegame.py
+++ b/apps/savegame/handlers/commands/savegame.py
@@ -56,7 +56,7 @@ def handle_determine_savegame_outcome(*, context: DetermineSavegameOutcome) -> E
     open_skirmish_list = list(
         Skirmish.objects.unresolved()
         .for_savegame(savegame_id=context.savegame.id)
-        .select_related("player_faction", "non_player_faction")
+        .select_related("attacking_faction", "defending_faction")
     )
 
     return SavegameEnded(

--- a/apps/savegame/tests/handlers/commands/test_savegame.py
+++ b/apps/savegame/tests/handlers/commands/test_savegame.py
@@ -78,7 +78,7 @@ def test_handle_determine_savegame_outcome_carries_the_unresolved_skirmish():
     savegame = SavegameFactory()
     savegame.player_faction = FactionFactory(savegame=savegame, is_defeated=True)
     savegame.save()
-    skirmish = SkirmishFactory(player_faction=savegame.player_faction)
+    skirmish = SkirmishFactory(attacking_faction=savegame.player_faction)
 
     result = handle_determine_savegame_outcome(context=DetermineSavegameOutcome(savegame=savegame))
 

--- a/apps/savegame/tests/test_flows.py
+++ b/apps/savegame/tests/test_flows.py
@@ -32,9 +32,9 @@ def test_losing_the_leader_ends_the_game_and_decides_the_open_fight(queuebie_reg
     player_faction.save()
 
     # The fight he fell in is still running, so ending the game has to decide it
-    skirmish = SkirmishFactory(player_faction=player_faction, non_player_faction=rival_faction)
-    skirmish.player_warriors.add(leader)
-    skirmish.non_player_warriors.add(WarriorFactory(faction=rival_faction, savegame=savegame))
+    skirmish = SkirmishFactory(attacking_faction=player_faction, defending_faction=rival_faction)
+    skirmish.attacking_warriors.add(leader)
+    skirmish.defending_warriors.add(WarriorFactory(faction=rival_faction, savegame=savegame))
 
     handle_message(DefeatFactionOfLostLeader(warrior=leader))
 
@@ -67,12 +67,12 @@ def test_a_warrior_in_two_open_fights_is_taken_prisoner_only_once(queuebie_regis
     player_faction.save()
 
     # He was committed to both fights, and neither has been played out
-    first_skirmish = SkirmishFactory(player_faction=player_faction, non_player_faction=first_rival)
-    first_skirmish.player_warriors.add(leader)
-    first_skirmish.non_player_warriors.add(WarriorFactory(faction=first_rival, savegame=savegame))
-    second_skirmish = SkirmishFactory(player_faction=player_faction, non_player_faction=second_rival)
-    second_skirmish.player_warriors.add(leader)
-    second_skirmish.non_player_warriors.add(WarriorFactory(faction=second_rival, savegame=savegame))
+    first_skirmish = SkirmishFactory(attacking_faction=player_faction, defending_faction=first_rival)
+    first_skirmish.attacking_warriors.add(leader)
+    first_skirmish.defending_warriors.add(WarriorFactory(faction=first_rival, savegame=savegame))
+    second_skirmish = SkirmishFactory(attacking_faction=player_faction, defending_faction=second_rival)
+    second_skirmish.attacking_warriors.add(leader)
+    second_skirmish.defending_warriors.add(WarriorFactory(faction=second_rival, savegame=savegame))
 
     handle_message(DefeatFactionOfLostLeader(warrior=leader))
 

--- a/apps/skirmish/admin.py
+++ b/apps/skirmish/admin.py
@@ -19,12 +19,12 @@ class SkirmishAdmin(admin.ModelAdmin):
     list_display = (
         "name",
         "current_round",
-        "player_faction",
-        "non_player_faction",
+        "attacking_faction",
+        "defending_faction",
         "victorious_faction",
     )
     list_filter = (
-        "player_faction__savegame",
+        "attacking_faction__savegame",
         "victorious_faction",
     )
 

--- a/apps/skirmish/handlers/commands/skirmish.py
+++ b/apps/skirmish/handlers/commands/skirmish.py
@@ -199,14 +199,14 @@ def handle_faction_wins_skirmish(*, context: skirmish.WinSkirmish) -> list[Event
         quest_loot = 0
 
     # Everything below is about the winner and the loser, so the two sides get sorted into those
-    # roles exactly once - "player_warriors" and "non_player_warriors" only coincide with them when
-    # the player happens to be the one who won
-    if context.skirmish.victorious_faction == context.skirmish.player_faction:
-        victorious_warriors = context.skirmish.player_warriors
-        defeated_warriors = context.skirmish.non_player_warriors
+    # roles exactly once - "attacking_warriors" and "defending_warriors" only coincide with them when
+    # the side that marched is the side that won
+    if context.skirmish.victorious_faction == context.skirmish.attacking_faction:
+        victorious_warriors = context.skirmish.attacking_warriors
+        defeated_warriors = context.skirmish.defending_warriors
     else:
-        victorious_warriors = context.skirmish.non_player_warriors
-        defeated_warriors = context.skirmish.player_warriors
+        victorious_warriors = context.skirmish.defending_warriors
+        defeated_warriors = context.skirmish.attacking_warriors
 
     # Only a warrior left lying on the field can be stripped: the dead and the unconscious. One who
     # fled took his kit with him, so a warband that merely routs loses nothing but the fight. That
@@ -255,11 +255,11 @@ def handle_finish_round(*, context: skirmish.FinishRound) -> list[Event] | Event
 
     # Check if one faction has been defeated
     victor = None
-    if not context.skirmish.non_player_warriors.filter(condition=Warrior.ConditionChoices.CONDITION_HEALTHY).exists():
+    if not context.skirmish.defending_warriors.filter(condition=Warrior.ConditionChoices.CONDITION_HEALTHY).exists():
         # Checked first on purpose: if both sides are wiped out in the same round, the tie goes to
-        # the player
-        victor = context.skirmish.player_faction
-    elif not context.skirmish.player_warriors.filter(condition=Warrior.ConditionChoices.CONDITION_HEALTHY).exists():
-        victor = context.skirmish.non_player_faction
+        # the side that marched
+        victor = context.skirmish.attacking_faction
+    elif not context.skirmish.attacking_warriors.filter(condition=Warrior.ConditionChoices.CONDITION_HEALTHY).exists():
+        victor = context.skirmish.defending_faction
 
     return RoundFinished(skirmish=context.skirmish, victor=victor, month=context.month)

--- a/apps/skirmish/handlers/commands/warrior.py
+++ b/apps/skirmish/handlers/commands/warrior.py
@@ -19,10 +19,10 @@ from apps.skirmish.models.warrior import Warrior
 
 @message_registry.register_command(command=warrior.ReduceMoraleOfRemainingWarriors)
 def handle_reduce_morale_of_remaining_warriors(*, context: warrior.ReduceMoraleOfRemainingWarriors) -> list[Command]:
-    if context.warrior.faction_id == context.skirmish.player_faction_id:
-        affected_warrior_list = context.skirmish.player_warriors.all()
+    if context.warrior.faction_id == context.skirmish.attacking_faction_id:
+        affected_warrior_list = context.skirmish.attacking_warriors.all()
     else:
-        affected_warrior_list = context.skirmish.non_player_warriors.all()
+        affected_warrior_list = context.skirmish.defending_warriors.all()
 
     # Every other warrior from the faction participating in this battle will lose 10% morale
     message_list = []

--- a/apps/skirmish/handlers/events/savegame.py
+++ b/apps/skirmish/handlers/events/savegame.py
@@ -14,17 +14,28 @@ def handle_win_open_skirmishes_when_the_game_ends(*, context: SavegameEnded) -> 
     It goes through WinSkirmish like any other victory rather than just stamping a victor on the row,
     so the loot, the prisoners, the experience and the quest contract all behave the way they would
     have if the fight had run its course.
+
+    The skirmish itself only knows an attacking and a defending side, so which of them the outcome
+    favours is a question for the savegame: the player faction sits on exactly one of them. Asking it
+    costs no query - "player_faction_id" is a column on the savegame already in hand, and the command
+    handler raising this event pulls both faction sides in with the skirmishes, which is the query
+    strict mode forbids here.
     """
+    player_won = context.outcome == Savegame.OutcomeChoices.OUTCOME_WON
     message_list = []
 
     for skirmish in context.open_skirmish_list:
+        # Asked as "is the player the attacker" rather than the other way round on purpose: a savegame
+        # with no player faction yet, or - once AI factions fight each other - a skirmish the player is
+        # not in at all, must not come out as "the player marched". Those land on the defending side,
+        # which is wrong for nobody today, because every skirmish that exists is one the player started
+        player_attacks = skirmish.attacking_faction_id == context.savegame.player_faction_id
+
         message_list.append(
             WinSkirmish(
                 skirmish=skirmish,
                 victorious_faction=(
-                    skirmish.player_faction
-                    if context.outcome == Savegame.OutcomeChoices.OUTCOME_WON
-                    else skirmish.non_player_faction
+                    skirmish.attacking_faction if player_attacks == player_won else skirmish.defending_faction
                 ),
                 month=context.month,
             )

--- a/apps/skirmish/management/commands/reset_skirmish.py
+++ b/apps/skirmish/management/commands/reset_skirmish.py
@@ -17,18 +17,18 @@ class Command(BaseCommand):
         skirmish.victorious_faction = None
         skirmish.save()
 
-        skirmish.player_warriors.update(
+        skirmish.attacking_warriors.update(
             current_health=F("max_health"),
             current_morale=F("max_morale"),
             condition=Warrior.ConditionChoices.CONDITION_HEALTHY,
         )
-        skirmish.non_player_warriors.update(
+        skirmish.defending_warriors.update(
             current_health=F("max_health"),
             current_morale=F("max_morale"),
             condition=Warrior.ConditionChoices.CONDITION_HEALTHY,
         )
 
-        skirmish.player_faction.captured_warriors.remove(*skirmish.player_faction.captured_warriors.all())
-        skirmish.non_player_faction.captured_warriors.remove(*skirmish.non_player_faction.captured_warriors.all())
+        skirmish.attacking_faction.captured_warriors.remove(*skirmish.attacking_faction.captured_warriors.all())
+        skirmish.defending_faction.captured_warriors.remove(*skirmish.defending_faction.captured_warriors.all())
 
         BattleHistory.objects.filter(skirmish=skirmish).delete()

--- a/apps/skirmish/managers/battle_history.py
+++ b/apps/skirmish/managers/battle_history.py
@@ -4,7 +4,7 @@ from django.db.models import manager
 
 class BattleHistoryQuerySet(models.QuerySet):
     def for_savegame(self, *, savegame_id: int):
-        return self.filter(skirmish__player_faction__savegame_id=savegame_id)
+        return self.filter(skirmish__attacking_faction__savegame_id=savegame_id)
 
 
 class BattleHistoryManager(manager.Manager):

--- a/apps/skirmish/managers/skirmish.py
+++ b/apps/skirmish/managers/skirmish.py
@@ -4,7 +4,7 @@ from django.db.models import manager
 
 class SkirmishQuerySet(models.QuerySet):
     def for_savegame(self, *, savegame_id: int):
-        return self.filter(player_faction__savegame_id=savegame_id)
+        return self.filter(attacking_faction__savegame_id=savegame_id)
 
     def unresolved(self):
         return self.filter(victorious_faction__isnull=True)

--- a/apps/skirmish/managers/warrior.py
+++ b/apps/skirmish/managers/warrior.py
@@ -29,9 +29,9 @@ class WarriorQuerySet(models.QuerySet):
         contracts it read per through-row instead: a warrior holding contracts in month 1 and month 3
         came back as free in month 3, because the month-1 row satisfied "this row is not month 3".
 
-        Both sides of a skirmish are asked, not just the player's: who counts as "the player" there
-        is a property of the row rather than of the warrior, and a captive who changed banners has
-        fought all the same.
+        Both sides of a skirmish are asked, attacking and defending alike: a captive who changed
+        banners has fought all the same, and a warrior is no less busy for having been the one
+        marched against.
         """
         # Imported here because the skirmish model reaches back into this module through the warrior
         # model it points at
@@ -44,7 +44,7 @@ class WarriorQuerySet(models.QuerySet):
         occupying_skirmishes = Skirmish.objects.filter(Q(month=month) | Q(victorious_faction__isnull=True))
 
         return self.exclude(quest_contracts__accepted_in_month=month).exclude(
-            Q(player_skirmishes__in=occupying_skirmishes) | Q(non_player_skirmishes__in=occupying_skirmishes)
+            Q(attacking_skirmishes__in=occupying_skirmishes) | Q(defending_skirmishes__in=occupying_skirmishes)
         )
 
 

--- a/apps/skirmish/migrations/0005_rename_skirmish_sides_to_attacker_and_defender.py
+++ b/apps/skirmish/migrations/0005_rename_skirmish_sides_to_attacker_and_defender.py
@@ -1,0 +1,70 @@
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("faction", "0001_initial"),
+        ("skirmish", "0004_skirmish_month"),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name="skirmish",
+            old_name="player_faction",
+            new_name="attacking_faction",
+        ),
+        migrations.RenameField(
+            model_name="skirmish",
+            old_name="non_player_faction",
+            new_name="defending_faction",
+        ),
+        migrations.RenameField(
+            model_name="skirmish",
+            old_name="player_warriors",
+            new_name="attacking_warriors",
+        ),
+        migrations.RenameField(
+            model_name="skirmish",
+            old_name="non_player_warriors",
+            new_name="defending_warriors",
+        ),
+        migrations.AlterField(
+            model_name="skirmish",
+            name="attacking_faction",
+            field=models.ForeignKey(
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name="attacking_skirmishes",
+                to="faction.faction",
+                verbose_name="Attacking faction",
+            ),
+        ),
+        migrations.AlterField(
+            model_name="skirmish",
+            name="defending_faction",
+            field=models.ForeignKey(
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name="defending_skirmishes",
+                to="faction.faction",
+                verbose_name="Defending faction",
+            ),
+        ),
+        migrations.AlterField(
+            model_name="skirmish",
+            name="attacking_warriors",
+            field=models.ManyToManyField(
+                related_name="attacking_skirmishes",
+                to="skirmish.warrior",
+                verbose_name="Attacking warriors",
+            ),
+        ),
+        migrations.AlterField(
+            model_name="skirmish",
+            name="defending_warriors",
+            field=models.ManyToManyField(
+                related_name="defending_skirmishes",
+                to="skirmish.warrior",
+                verbose_name="Defending warriors",
+            ),
+        ),
+    ]

--- a/apps/skirmish/models/skirmish.py
+++ b/apps/skirmish/models/skirmish.py
@@ -12,17 +12,18 @@ class Skirmish(models.Model):
     # but an attack carries no contract
     month = models.PositiveSmallIntegerField("Month", default=1)
 
-    # TODO: we could change this to attacker and defender and make AI factions fight themselves
-    player_faction = models.ForeignKey(
+    # Named for the role each side plays in the fight. Which of them the player holds - if either - is
+    # a question for the savegame, so nothing here has to be true of every skirmish ever created
+    attacking_faction = models.ForeignKey(
         "faction.Faction",
-        verbose_name="Player faction",
-        related_name="player_skirmishes",
+        verbose_name="Attacking faction",
+        related_name="attacking_skirmishes",
         on_delete=models.CASCADE,
     )
-    non_player_faction = models.ForeignKey(
+    defending_faction = models.ForeignKey(
         "faction.Faction",
-        verbose_name="Non-player faction",
-        related_name="non_player_skirmishes",
+        verbose_name="Defending faction",
+        related_name="defending_skirmishes",
         on_delete=models.CASCADE,
     )
     victorious_faction = models.ForeignKey(
@@ -33,15 +34,15 @@ class Skirmish(models.Model):
         null=True,
         blank=True,
     )
-    player_warriors = models.ManyToManyField(
+    attacking_warriors = models.ManyToManyField(
         Warrior,
-        verbose_name="Player warriors",
-        related_name="player_skirmishes",
+        verbose_name="Attacking warriors",
+        related_name="attacking_skirmishes",
     )
-    non_player_warriors = models.ManyToManyField(
+    defending_warriors = models.ManyToManyField(
         Warrior,
-        verbose_name="Non-player warriors",
-        related_name="non_player_skirmishes",
+        verbose_name="Defending warriors",
+        related_name="defending_skirmishes",
     )
 
     objects = SkirmishManager()

--- a/apps/skirmish/services/generators/skirmish/base.py
+++ b/apps/skirmish/services/generators/skirmish/base.py
@@ -26,12 +26,12 @@ class BaseSkirmishGenerator:
 
         skirmish = Skirmish.objects.create(
             name=self.name,
-            player_faction_id=self.warriors_faction_1[0].faction.id,
-            non_player_faction_id=self.warriors_faction_2[0].faction.id,
+            attacking_faction_id=self.warriors_faction_1[0].faction.id,
+            defending_faction_id=self.warriors_faction_2[0].faction.id,
             month=self.month,
         )
 
-        skirmish.player_warriors.add(*self.warriors_faction_1)
-        skirmish.non_player_warriors.add(*self.warriors_faction_2)
+        skirmish.attacking_warriors.add(*self.warriors_faction_1)
+        skirmish.defending_warriors.add(*self.warriors_faction_2)
 
         return skirmish

--- a/apps/skirmish/templates/skirmish/skirmish_fight.html
+++ b/apps/skirmish/templates/skirmish/skirmish_fight.html
@@ -5,7 +5,7 @@
 
     <div class="uk-grid-match uk-child-width-1-3@m" uk-grid>
         <div>
-            {% include 'skirmish/faction/components/faction_box.html' with faction=player_faction warrior_list=skirmish.player_warriors.all is_player=True %}
+            {% include 'skirmish/faction/components/faction_box.html' with faction=attacking_faction warrior_list=skirmish.attacking_warriors.all is_player=attacker_is_player %}
         </div>
         <div>
             <div class="uk-tile-muted uk-padding-large">
@@ -29,7 +29,7 @@
             </div>
         </div>
         <div>
-            {% include 'skirmish/faction/components/faction_box.html' with faction=non_player_faction warrior_list=skirmish.non_player_warriors.all is_player=False %}
+            {% include 'skirmish/faction/components/faction_box.html' with faction=defending_faction warrior_list=skirmish.defending_warriors.all is_player=defender_is_player %}
         </div>
     </div>
 {% endblock content %}

--- a/apps/skirmish/templates/skirmish/skirmish_list.html
+++ b/apps/skirmish/templates/skirmish/skirmish_list.html
@@ -7,8 +7,8 @@
         <thead>
         <tr>
             <th>Name</th>
-            <th>Player faction</th>
-            <th>Non-player faction</th>
+            <th>Attacker</th>
+            <th>Defender</th>
             <th>Rounds</th>
             <th>Victor</th>
             <th></th>
@@ -18,8 +18,8 @@
         {% for skirmish in object_list %}
             <tr>
                 <td>{{ skirmish.name }}</td>
-                <td>{{ skirmish.player_faction }}</td>
-                <td>{{ skirmish.non_player_faction }}</td>
+                <td>{{ skirmish.attacking_faction }}</td>
+                <td>{{ skirmish.defending_faction }}</td>
                 <td>{{ skirmish.current_round }}</td>
                 <td>{{ skirmish.victorious_faction|default_if_none:"-" }}</td>
                 <td>

--- a/apps/skirmish/tests/factories/skirmish.py
+++ b/apps/skirmish/tests/factories/skirmish.py
@@ -10,6 +10,8 @@ class SkirmishFactory(DjangoModelFactory):
         model = Skirmish
 
     name = factory.Sequence(lambda n: f"Skirmish {n}")
-    player_faction = factory.SubFactory(FactionFactory)
+    attacking_faction = factory.SubFactory(FactionFactory)
     # Keep both factions inside the same savegame
-    non_player_faction = factory.SubFactory(FactionFactory, savegame=factory.SelfAttribute("..player_faction.savegame"))
+    defending_faction = factory.SubFactory(
+        FactionFactory, savegame=factory.SelfAttribute("..attacking_faction.savegame")
+    )

--- a/apps/skirmish/tests/handlers/commands/test_item.py
+++ b/apps/skirmish/tests/handlers/commands/test_item.py
@@ -13,15 +13,15 @@ from apps.skirmish.tests.factories.warrior import WarriorFactory
 @pytest.mark.django_db
 def test_handle_warrior_drops_loot_drops_weapon_and_armor():
     skirmish = SkirmishFactory()
-    weapon = ItemFactory(savegame=skirmish.player_faction.savegame)
+    weapon = ItemFactory(savegame=skirmish.attacking_faction.savegame)
     armor = ItemFactory(
-        savegame=skirmish.player_faction.savegame,
+        savegame=skirmish.attacking_faction.savegame,
         type=ItemTypeFactory(function=ItemType.FunctionChoices.FUNCTION_ARMOR),
     )
-    warrior = WarriorFactory(faction=skirmish.non_player_faction, weapon=weapon, armor=armor)
+    warrior = WarriorFactory(faction=skirmish.defending_faction, weapon=weapon, armor=armor)
 
     result = handle_warrior_drops_loot(
-        context=WarriorDropsLoot(skirmish=skirmish, warrior=warrior, new_owner=skirmish.player_faction)
+        context=WarriorDropsLoot(skirmish=skirmish, warrior=warrior, new_owner=skirmish.attacking_faction)
     )
 
     assert result == [
@@ -30,14 +30,14 @@ def test_handle_warrior_drops_loot_drops_weapon_and_armor():
             warrior=warrior,
             item=weapon,
             item_name=weapon.display_name,
-            new_owner=skirmish.player_faction,
+            new_owner=skirmish.attacking_faction,
         ),
         ItemDroppedAsLoot(
             skirmish=skirmish,
             warrior=warrior,
             item=armor,
             item_name=armor.display_name,
-            new_owner=skirmish.player_faction,
+            new_owner=skirmish.attacking_faction,
         ),
     ]
 
@@ -45,10 +45,10 @@ def test_handle_warrior_drops_loot_drops_weapon_and_armor():
 @pytest.mark.django_db
 def test_handle_warrior_drops_loot_drops_nothing_for_an_unequipped_warrior():
     skirmish = SkirmishFactory()
-    warrior = WarriorFactory(faction=skirmish.non_player_faction, weapon=None, armor=None)
+    warrior = WarriorFactory(faction=skirmish.defending_faction, weapon=None, armor=None)
 
     result = handle_warrior_drops_loot(
-        context=WarriorDropsLoot(skirmish=skirmish, warrior=warrior, new_owner=skirmish.player_faction)
+        context=WarriorDropsLoot(skirmish=skirmish, warrior=warrior, new_owner=skirmish.attacking_faction)
     )
 
     assert result == []

--- a/apps/skirmish/tests/handlers/commands/test_skirmish.py
+++ b/apps/skirmish/tests/handlers/commands/test_skirmish.py
@@ -42,26 +42,26 @@ def test_handle_attack_faction_fields_the_targets_own_warriors():
     The point of the whole story: the defending side is the rival's actual war band, its leader
     among them, rather than mercenaries invented for the occasion.
     """
-    player_faction = FactionFactory()
-    target_faction = FactionFactory(savegame=player_faction.savegame)
-    player_leader = WarriorFactory(faction=player_faction)
+    attacking_faction = FactionFactory()
+    target_faction = FactionFactory(savegame=attacking_faction.savegame)
+    attacking_leader = WarriorFactory(faction=attacking_faction)
     target_leader = WarriorFactory(faction=target_faction)
     target_faction.leader = target_leader
     target_faction.save()
 
     result = handle_attack_faction(
         context=AttackFaction(
-            attacking_faction=player_faction,
+            attacking_faction=attacking_faction,
             target_faction=target_faction,
-            assigned_warriors=[player_leader],
+            assigned_warriors=[attacking_leader],
             month=3,
         )
     )
 
     assert result == FactionWasAttacked(
-        attacking_faction=player_faction,
+        attacking_faction=attacking_faction,
         defending_faction=target_faction,
-        attacking_warriors=[player_leader],
+        attacking_warriors=[attacking_leader],
         defending_warriors=[target_leader],
         month=3,
     )
@@ -73,16 +73,16 @@ def test_handle_attack_faction_leaves_the_targets_casualties_out_of_the_line_up(
     A warrior who is down does not turn out to defend his town - and a side made up of him alone
     would count as beaten before the first round.
     """
-    player_faction = FactionFactory()
-    target_faction = FactionFactory(savegame=player_faction.savegame)
+    attacking_faction = FactionFactory()
+    target_faction = FactionFactory(savegame=attacking_faction.savegame)
     healthy_defender = WarriorFactory(faction=target_faction)
     WarriorFactory(faction=target_faction, condition=Warrior.ConditionChoices.CONDITION_UNCONSCIOUS)
 
     result = handle_attack_faction(
         context=AttackFaction(
-            attacking_faction=player_faction,
+            attacking_faction=attacking_faction,
             target_faction=target_faction,
-            assigned_warriors=[WarriorFactory(faction=player_faction)],
+            assigned_warriors=[WarriorFactory(faction=attacking_faction)],
             month=3,
         )
     )
@@ -93,7 +93,7 @@ def test_handle_attack_faction_leaves_the_targets_casualties_out_of_the_line_up(
 @pytest.mark.django_db
 def test_handle_create_skirmish_uses_the_given_opponents():
     quest_contract = QuestContractFactory()
-    player_warrior = WarriorFactory(faction=quest_contract.faction)
+    attacking_warrior = WarriorFactory(faction=quest_contract.faction)
     enemy_warrior = WarriorFactory(faction=quest_contract.quest.target_faction)
 
     result = handle_create_skirmish(
@@ -101,15 +101,15 @@ def test_handle_create_skirmish_uses_the_given_opponents():
             name="Ambush",
             faction_1=quest_contract.faction,
             faction_2=quest_contract.quest.target_faction,
-            warrior_list_1=[player_warrior],
+            warrior_list_1=[attacking_warrior],
             warrior_list_2=[enemy_warrior],
             month=3,
             quest_contract=quest_contract,
         )
     )
 
-    assert list(result.skirmish.player_warriors.all()) == [player_warrior]
-    assert list(result.skirmish.non_player_warriors.all()) == [enemy_warrior]
+    assert list(result.skirmish.attacking_warriors.all()) == [attacking_warrior]
+    assert list(result.skirmish.defending_warriors.all()) == [enemy_warrior]
 
 
 @pytest.mark.django_db
@@ -119,7 +119,7 @@ def test_handle_create_skirmish_records_the_month():
     twice has nothing else to go on.
     """
     quest_contract = QuestContractFactory()
-    player_warrior = WarriorFactory(faction=quest_contract.faction)
+    attacking_warrior = WarriorFactory(faction=quest_contract.faction)
     enemy_warrior = WarriorFactory(faction=quest_contract.quest.target_faction)
 
     result = handle_create_skirmish(
@@ -127,7 +127,7 @@ def test_handle_create_skirmish_records_the_month():
             name="Ambush",
             faction_1=quest_contract.faction,
             faction_2=quest_contract.quest.target_faction,
-            warrior_list_1=[player_warrior],
+            warrior_list_1=[attacking_warrior],
             warrior_list_2=[enemy_warrior],
             month=7,
             quest_contract=quest_contract,
@@ -140,7 +140,7 @@ def test_handle_create_skirmish_records_the_month():
 @pytest.mark.django_db
 def test_handle_create_skirmish_generates_opponents_when_none_are_given():
     quest_contract = QuestContractFactory()
-    player_warrior = WarriorFactory(faction=quest_contract.faction)
+    attacking_warrior = WarriorFactory(faction=quest_contract.faction)
     ItemTypeFactory(function=ItemType.FunctionChoices.FUNCTION_WEAPON)
     ItemTypeFactory(function=ItemType.FunctionChoices.FUNCTION_ARMOR)
 
@@ -151,14 +151,14 @@ def test_handle_create_skirmish_generates_opponents_when_none_are_given():
                 name="Ambush",
                 faction_1=quest_contract.faction,
                 faction_2=quest_contract.quest.target_faction,
-                warrior_list_1=[player_warrior],
+                warrior_list_1=[attacking_warrior],
                 warrior_list_2=None,
                 month=3,
                 quest_contract=quest_contract,
             )
         )
 
-    assert result.skirmish.non_player_warriors.count() == 2
+    assert result.skirmish.defending_warriors.count() == 2
 
 
 @pytest.mark.django_db
@@ -168,17 +168,17 @@ def test_handle_create_skirmish_does_not_generate_opponents_for_an_empty_list():
     "no opponents were supplied" - and invented mercenaries for a faction that has none, on a path
     that then dereferenced the quest contract an attack does not carry.
     """
-    player_faction = FactionFactory()
-    enemy_faction = FactionFactory(savegame=player_faction.savegame)
-    player_warrior = WarriorFactory(faction=player_faction)
+    attacking_faction = FactionFactory()
+    enemy_faction = FactionFactory(savegame=attacking_faction.savegame)
+    attacking_warrior = WarriorFactory(faction=attacking_faction)
 
     with pytest.raises(RuntimeError, match="no warriors on the defending side"):
         handle_create_skirmish(
             context=CreateSkirmish(
                 name="Brawl",
-                faction_1=player_faction,
+                faction_1=attacking_faction,
                 faction_2=enemy_faction,
-                warrior_list_1=[player_warrior],
+                warrior_list_1=[attacking_warrior],
                 warrior_list_2=[],
                 month=3,
                 quest_contract=None,
@@ -189,7 +189,7 @@ def test_handle_create_skirmish_does_not_generate_opponents_for_an_empty_list():
 @pytest.mark.django_db
 def test_handle_create_skirmish_passes_the_quest_contract_on():
     quest_contract = QuestContractFactory()
-    player_warrior = WarriorFactory(faction=quest_contract.faction)
+    attacking_warrior = WarriorFactory(faction=quest_contract.faction)
     enemy_warrior = WarriorFactory(faction=quest_contract.quest.target_faction)
 
     result = handle_create_skirmish(
@@ -197,7 +197,7 @@ def test_handle_create_skirmish_passes_the_quest_contract_on():
             name="Ambush",
             faction_1=quest_contract.faction,
             faction_2=quest_contract.quest.target_faction,
-            warrior_list_1=[player_warrior],
+            warrior_list_1=[attacking_warrior],
             warrior_list_2=[enemy_warrior],
             month=3,
             quest_contract=quest_contract,
@@ -209,17 +209,17 @@ def test_handle_create_skirmish_passes_the_quest_contract_on():
 
 @pytest.mark.django_db
 def test_handle_create_skirmish_without_a_quest_contract():
-    player_faction = FactionFactory()
-    enemy_faction = FactionFactory(savegame=player_faction.savegame)
-    player_warrior = WarriorFactory(faction=player_faction)
+    attacking_faction = FactionFactory()
+    enemy_faction = FactionFactory(savegame=attacking_faction.savegame)
+    attacking_warrior = WarriorFactory(faction=attacking_faction)
     enemy_warrior = WarriorFactory(faction=enemy_faction)
 
     result = handle_create_skirmish(
         context=CreateSkirmish(
             name="Brawl",
-            faction_1=player_faction,
+            faction_1=attacking_faction,
             faction_2=enemy_faction,
-            warrior_list_1=[player_warrior],
+            warrior_list_1=[attacking_warrior],
             warrior_list_2=[enemy_warrior],
             month=3,
             quest_contract=None,
@@ -232,12 +232,12 @@ def test_handle_create_skirmish_without_a_quest_contract():
 @pytest.mark.django_db
 def test_handle_assign_fighter_pairs_matches_equally_sized_groups():
     skirmish = SkirmishFactory()
-    player_participant = SkirmishParticipant(
-        warrior=WarriorFactory(faction=skirmish.player_faction),
+    attacking_participant = SkirmishParticipant(
+        warrior=WarriorFactory(faction=skirmish.attacking_faction),
         skirmish_action=SkirmishActionChoices.SIMPLE_ATTACK,
     )
     enemy_participant = SkirmishParticipant(
-        warrior=WarriorFactory(faction=skirmish.non_player_faction),
+        warrior=WarriorFactory(faction=skirmish.defending_faction),
         skirmish_action=SkirmishActionChoices.DEFENSIVE_STANCE,
     )
 
@@ -246,7 +246,7 @@ def test_handle_assign_fighter_pairs_matches_equally_sized_groups():
         result = handle_assign_fighter_pairs(
             context=StartDuel(
                 skirmish=skirmish,
-                skirmish_participants_1=[player_participant],
+                skirmish_participants_1=[attacking_participant],
                 skirmish_participants_2=[enemy_participant],
             )
         )
@@ -254,7 +254,7 @@ def test_handle_assign_fighter_pairs_matches_equally_sized_groups():
     assert result == [
         FighterPairsMatched(
             skirmish=skirmish,
-            warrior_1=player_participant.warrior,
+            warrior_1=attacking_participant.warrior,
             warrior_2=enemy_participant.warrior,
             attack_action_1=SkirmishActionChoices.SIMPLE_ATTACK,
             attack_action_2=SkirmishActionChoices.DEFENSIVE_STANCE,
@@ -265,16 +265,16 @@ def test_handle_assign_fighter_pairs_matches_equally_sized_groups():
 @pytest.mark.django_db
 def test_handle_assign_fighter_pairs_grants_a_free_attack_to_the_more_numerous_group():
     skirmish = SkirmishFactory()
-    first_player_participant = SkirmishParticipant(
-        warrior=WarriorFactory(faction=skirmish.player_faction),
+    first_attacking_participant = SkirmishParticipant(
+        warrior=WarriorFactory(faction=skirmish.attacking_faction),
         skirmish_action=SkirmishActionChoices.SIMPLE_ATTACK,
     )
-    second_player_participant = SkirmishParticipant(
-        warrior=WarriorFactory(faction=skirmish.player_faction),
+    second_attacking_participant = SkirmishParticipant(
+        warrior=WarriorFactory(faction=skirmish.attacking_faction),
         skirmish_action=SkirmishActionChoices.FAST_ATTACK,
     )
     enemy_participant = SkirmishParticipant(
-        warrior=WarriorFactory(faction=skirmish.non_player_faction),
+        warrior=WarriorFactory(faction=skirmish.defending_faction),
         skirmish_action=SkirmishActionChoices.DEFENSIVE_STANCE,
     )
 
@@ -283,7 +283,7 @@ def test_handle_assign_fighter_pairs_grants_a_free_attack_to_the_more_numerous_g
         result = handle_assign_fighter_pairs(
             context=StartDuel(
                 skirmish=skirmish,
-                skirmish_participants_1=[first_player_participant, second_player_participant],
+                skirmish_participants_1=[first_attacking_participant, second_attacking_participant],
                 skirmish_participants_2=[enemy_participant],
             )
         )
@@ -291,14 +291,14 @@ def test_handle_assign_fighter_pairs_grants_a_free_attack_to_the_more_numerous_g
     assert result == [
         FighterPairsMatched(
             skirmish=skirmish,
-            warrior_1=first_player_participant.warrior,
+            warrior_1=first_attacking_participant.warrior,
             warrior_2=enemy_participant.warrior,
             attack_action_1=SkirmishActionChoices.SIMPLE_ATTACK,
             attack_action_2=SkirmishActionChoices.DEFENSIVE_STANCE,
         ),
         AttackerDefenderDecided(
             skirmish=skirmish,
-            attacker=second_player_participant.warrior,
+            attacker=second_attacking_participant.warrior,
             attacker_action=SkirmishActionChoices.FAST_ATTACK,
             defender=enemy_participant.warrior,
             defender_action=SkirmishActionChoices.DEFENSIVE_STANCE,
@@ -309,15 +309,15 @@ def test_handle_assign_fighter_pairs_grants_a_free_attack_to_the_more_numerous_g
 @pytest.mark.django_db
 def test_handle_determine_attacker_and_defender_lets_the_first_warrior_attack():
     skirmish = SkirmishFactory()
-    player_warrior = WarriorFactory(faction=skirmish.player_faction, dexterity=10)
-    enemy_warrior = WarriorFactory(faction=skirmish.non_player_faction, dexterity=10)
+    attacking_warrior = WarriorFactory(faction=skirmish.attacking_faction, dexterity=10)
+    enemy_warrior = WarriorFactory(faction=skirmish.defending_faction, dexterity=10)
 
     # Boundary randomness: equal matching points are decided by a random draw
     with mock.patch("apps.skirmish.handlers.commands.skirmish.random.random", return_value=0.2):
         result = handle_determine_attacker_and_defender(
             context=DetermineAttacker(
                 skirmish=skirmish,
-                warrior_1=player_warrior,
+                warrior_1=attacking_warrior,
                 action_1=SkirmishActionChoices.SIMPLE_ATTACK,
                 warrior_2=enemy_warrior,
                 action_2=SkirmishActionChoices.SIMPLE_ATTACK,
@@ -326,7 +326,7 @@ def test_handle_determine_attacker_and_defender_lets_the_first_warrior_attack():
 
     assert result == AttackerDefenderDecided(
         skirmish=skirmish,
-        attacker=player_warrior,
+        attacker=attacking_warrior,
         attacker_action=SkirmishActionChoices.SIMPLE_ATTACK,
         defender=enemy_warrior,
         defender_action=SkirmishActionChoices.SIMPLE_ATTACK,
@@ -336,15 +336,15 @@ def test_handle_determine_attacker_and_defender_lets_the_first_warrior_attack():
 @pytest.mark.django_db
 def test_handle_determine_attacker_and_defender_lets_the_second_warrior_attack():
     skirmish = SkirmishFactory()
-    player_warrior = WarriorFactory(faction=skirmish.player_faction, dexterity=10)
-    enemy_warrior = WarriorFactory(faction=skirmish.non_player_faction, dexterity=10)
+    attacking_warrior = WarriorFactory(faction=skirmish.attacking_faction, dexterity=10)
+    enemy_warrior = WarriorFactory(faction=skirmish.defending_faction, dexterity=10)
 
     # Boundary randomness: equal matching points are decided by a random draw
     with mock.patch("apps.skirmish.handlers.commands.skirmish.random.random", return_value=0.8):
         result = handle_determine_attacker_and_defender(
             context=DetermineAttacker(
                 skirmish=skirmish,
-                warrior_1=player_warrior,
+                warrior_1=attacking_warrior,
                 action_1=SkirmishActionChoices.SIMPLE_ATTACK,
                 warrior_2=enemy_warrior,
                 action_2=SkirmishActionChoices.SIMPLE_ATTACK,
@@ -355,7 +355,7 @@ def test_handle_determine_attacker_and_defender_lets_the_second_warrior_attack()
         skirmish=skirmish,
         attacker=enemy_warrior,
         attacker_action=SkirmishActionChoices.SIMPLE_ATTACK,
-        defender=player_warrior,
+        defender=attacking_warrior,
         defender_action=SkirmishActionChoices.SIMPLE_ATTACK,
     )
 
@@ -363,13 +363,13 @@ def test_handle_determine_attacker_and_defender_lets_the_second_warrior_attack()
 @pytest.mark.django_db
 def test_handle_determine_attacker_and_defender_with_two_defensive_stances():
     skirmish = SkirmishFactory()
-    player_warrior = WarriorFactory(faction=skirmish.player_faction, dexterity=10)
-    enemy_warrior = WarriorFactory(faction=skirmish.non_player_faction, dexterity=10)
+    attacking_warrior = WarriorFactory(faction=skirmish.attacking_faction, dexterity=10)
+    enemy_warrior = WarriorFactory(faction=skirmish.defending_faction, dexterity=10)
 
     result = handle_determine_attacker_and_defender(
         context=DetermineAttacker(
             skirmish=skirmish,
-            warrior_1=player_warrior,
+            warrior_1=attacking_warrior,
             action_1=SkirmishActionChoices.DEFENSIVE_STANCE,
             warrior_2=enemy_warrior,
             action_2=SkirmishActionChoices.DEFENSIVE_STANCE,
@@ -378,7 +378,7 @@ def test_handle_determine_attacker_and_defender_with_two_defensive_stances():
 
     assert result == AttackerDefenderDecided(
         skirmish=skirmish,
-        attacker=player_warrior,
+        attacker=attacking_warrior,
         attacker_action=SkirmishActionChoices.DEFENSIVE_STANCE,
         defender=enemy_warrior,
         defender_action=SkirmishActionChoices.DEFENSIVE_STANCE,
@@ -386,39 +386,39 @@ def test_handle_determine_attacker_and_defender_with_two_defensive_stances():
 
 
 @pytest.mark.django_db
-def test_handle_faction_wins_skirmish_loots_and_captures_for_the_player():
+def test_handle_faction_wins_skirmish_loots_and_captures_for_the_attacking_faction():
     """
     Both sides carry someone who is neither dead nor healthy, because that is where the two rules
     differ: the loser's unconscious are stripped where they lie, the winner's own are not, and the
     one who fled is gone with his kit whichever side he was on.
     """
     skirmish = SkirmishFactory()
-    quest_contract = QuestContractFactory(faction=skirmish.player_faction, skirmish=skirmish, quest__loot=250)
-    dead_player_warrior = WarriorFactory(
-        faction=skirmish.player_faction, condition=Warrior.ConditionChoices.CONDITION_DEAD
+    quest_contract = QuestContractFactory(faction=skirmish.attacking_faction, skirmish=skirmish, quest__loot=250)
+    dead_attacking_warrior = WarriorFactory(
+        faction=skirmish.attacking_faction, condition=Warrior.ConditionChoices.CONDITION_DEAD
     )
-    unconscious_player_warrior = WarriorFactory(
-        faction=skirmish.player_faction, condition=Warrior.ConditionChoices.CONDITION_UNCONSCIOUS
+    unconscious_attacking_warrior = WarriorFactory(
+        faction=skirmish.attacking_faction, condition=Warrior.ConditionChoices.CONDITION_UNCONSCIOUS
     )
-    healthy_player_warrior = WarriorFactory(faction=skirmish.player_faction)
+    healthy_attacking_warrior = WarriorFactory(faction=skirmish.attacking_faction)
     unconscious_enemy_warrior = WarriorFactory(
-        faction=skirmish.non_player_faction, condition=Warrior.ConditionChoices.CONDITION_UNCONSCIOUS
+        faction=skirmish.defending_faction, condition=Warrior.ConditionChoices.CONDITION_UNCONSCIOUS
     )
     fleeing_enemy_warrior = WarriorFactory(
-        faction=skirmish.non_player_faction, condition=Warrior.ConditionChoices.CONDITION_FLEEING
+        faction=skirmish.defending_faction, condition=Warrior.ConditionChoices.CONDITION_FLEEING
     )
-    skirmish.player_warriors.add(dead_player_warrior, unconscious_player_warrior, healthy_player_warrior)
-    skirmish.non_player_warriors.add(unconscious_enemy_warrior, fleeing_enemy_warrior)
+    skirmish.attacking_warriors.add(dead_attacking_warrior, unconscious_attacking_warrior, healthy_attacking_warrior)
+    skirmish.defending_warriors.add(unconscious_enemy_warrior, fleeing_enemy_warrior)
 
     result = handle_faction_wins_skirmish(
-        context=WinSkirmish(skirmish=skirmish, victorious_faction=skirmish.player_faction, month=3)
+        context=WinSkirmish(skirmish=skirmish, victorious_faction=skirmish.attacking_faction, month=3)
     )
 
     assert result == SkirmishFinished(
         skirmish=skirmish,
-        incapacitated_warriors=[dead_player_warrior, unconscious_enemy_warrior],
+        incapacitated_warriors=[dead_attacking_warrior, unconscious_enemy_warrior],
         defeated_unconscious_warriors=[unconscious_enemy_warrior],
-        victorious_healthy_warriors=[healthy_player_warrior],
+        victorious_healthy_warriors=[healthy_attacking_warrior],
         quest_name=quest_contract.quest.name,
         quest_loot=250,
         month=3,
@@ -433,15 +433,15 @@ def test_handle_faction_wins_skirmish_does_not_loot_a_warband_that_fled():
     weapon and piece of armour he owns for running away.
     """
     skirmish = SkirmishFactory()
-    fleeing_player_warrior = WarriorFactory(
-        faction=skirmish.player_faction, condition=Warrior.ConditionChoices.CONDITION_FLEEING
+    fleeing_attacking_warrior = WarriorFactory(
+        faction=skirmish.attacking_faction, condition=Warrior.ConditionChoices.CONDITION_FLEEING
     )
-    healthy_enemy_warrior = WarriorFactory(faction=skirmish.non_player_faction)
-    skirmish.player_warriors.add(fleeing_player_warrior)
-    skirmish.non_player_warriors.add(healthy_enemy_warrior)
+    healthy_enemy_warrior = WarriorFactory(faction=skirmish.defending_faction)
+    skirmish.attacking_warriors.add(fleeing_attacking_warrior)
+    skirmish.defending_warriors.add(healthy_enemy_warrior)
 
     result = handle_faction_wins_skirmish(
-        context=WinSkirmish(skirmish=skirmish, victorious_faction=skirmish.non_player_faction, month=3)
+        context=WinSkirmish(skirmish=skirmish, victorious_faction=skirmish.defending_faction, month=3)
     )
 
     assert result.incapacitated_warriors == []
@@ -452,47 +452,49 @@ def test_handle_faction_wins_skirmish_does_not_loot_a_warband_that_fled():
 def test_handle_faction_wins_skirmish_pays_no_quest_loot_to_a_rival_victor():
     """
     The reward is handed to whoever won further down the chain, so carrying it regardless of the
-    outcome credited the rival with the player's own quest money.
+    outcome credited the rival with the contract holder's own quest money.
     """
     skirmish = SkirmishFactory()
-    QuestContractFactory(faction=skirmish.player_faction, skirmish=skirmish, quest__loot=250)
-    skirmish.player_warriors.add(WarriorFactory(faction=skirmish.player_faction))
-    skirmish.non_player_warriors.add(WarriorFactory(faction=skirmish.non_player_faction))
+    QuestContractFactory(faction=skirmish.attacking_faction, skirmish=skirmish, quest__loot=250)
+    skirmish.attacking_warriors.add(WarriorFactory(faction=skirmish.attacking_faction))
+    skirmish.defending_warriors.add(WarriorFactory(faction=skirmish.defending_faction))
 
     result = handle_faction_wins_skirmish(
-        context=WinSkirmish(skirmish=skirmish, victorious_faction=skirmish.non_player_faction, month=3)
+        context=WinSkirmish(skirmish=skirmish, victorious_faction=skirmish.defending_faction, month=3)
     )
 
     assert result.quest_loot == 0
 
 
 @pytest.mark.django_db
-def test_handle_faction_wins_skirmish_loots_and_captures_for_the_non_player_faction():
+def test_handle_faction_wins_skirmish_loots_and_captures_for_the_defending_faction():
     """
-    The mirror image of the test above: the loot follows the victor, not the player. Naming the two
-    sides "player" and "non_player" used to make this case take the winner's items from the loser's
-    side and vice versa, so a losing player kept the gear of everyone who was merely knocked out.
+    The mirror image of the test above: the loot follows the victor, not the side that marched.
+
+    Back when the two sides were named after the player rather than their role, this case took the
+    winner's items from the loser's side and vice versa, so a losing player kept the gear of everyone
+    who was merely knocked out.
     """
     skirmish = SkirmishFactory()
-    quest_contract = QuestContractFactory(faction=skirmish.player_faction, skirmish=skirmish, quest__loot=250)
-    unconscious_player_warrior = WarriorFactory(
-        faction=skirmish.player_faction, condition=Warrior.ConditionChoices.CONDITION_UNCONSCIOUS
+    quest_contract = QuestContractFactory(faction=skirmish.attacking_faction, skirmish=skirmish, quest__loot=250)
+    unconscious_attacking_warrior = WarriorFactory(
+        faction=skirmish.attacking_faction, condition=Warrior.ConditionChoices.CONDITION_UNCONSCIOUS
     )
     dead_enemy_warrior = WarriorFactory(
-        faction=skirmish.non_player_faction, condition=Warrior.ConditionChoices.CONDITION_DEAD
+        faction=skirmish.defending_faction, condition=Warrior.ConditionChoices.CONDITION_DEAD
     )
-    healthy_enemy_warrior = WarriorFactory(faction=skirmish.non_player_faction)
-    skirmish.player_warriors.add(unconscious_player_warrior)
-    skirmish.non_player_warriors.add(dead_enemy_warrior, healthy_enemy_warrior)
+    healthy_enemy_warrior = WarriorFactory(faction=skirmish.defending_faction)
+    skirmish.attacking_warriors.add(unconscious_attacking_warrior)
+    skirmish.defending_warriors.add(dead_enemy_warrior, healthy_enemy_warrior)
 
     result = handle_faction_wins_skirmish(
-        context=WinSkirmish(skirmish=skirmish, victorious_faction=skirmish.non_player_faction, month=3)
+        context=WinSkirmish(skirmish=skirmish, victorious_faction=skirmish.defending_faction, month=3)
     )
 
     assert result == SkirmishFinished(
         skirmish=skirmish,
-        incapacitated_warriors=[dead_enemy_warrior, unconscious_player_warrior],
-        defeated_unconscious_warriors=[unconscious_player_warrior],
+        incapacitated_warriors=[dead_enemy_warrior, unconscious_attacking_warrior],
+        defeated_unconscious_warriors=[unconscious_attacking_warrior],
         victorious_healthy_warriors=[healthy_enemy_warrior],
         quest_name=quest_contract.quest.name,
         quest_loot=0,
@@ -506,18 +508,18 @@ def test_handle_faction_wins_skirmish_without_a_quest_contract():
     Not every skirmish belongs to a quest, so winning one without a contract has to work.
     """
     skirmish = SkirmishFactory()
-    healthy_player_warrior = WarriorFactory(faction=skirmish.player_faction)
-    skirmish.player_warriors.add(healthy_player_warrior)
+    healthy_attacking_warrior = WarriorFactory(faction=skirmish.attacking_faction)
+    skirmish.attacking_warriors.add(healthy_attacking_warrior)
 
     result = handle_faction_wins_skirmish(
-        context=WinSkirmish(skirmish=skirmish, victorious_faction=skirmish.player_faction, month=3)
+        context=WinSkirmish(skirmish=skirmish, victorious_faction=skirmish.attacking_faction, month=3)
     )
 
     assert result == SkirmishFinished(
         skirmish=skirmish,
         incapacitated_warriors=[],
         defeated_unconscious_warriors=[],
-        victorious_healthy_warriors=[healthy_player_warrior],
+        victorious_healthy_warriors=[healthy_attacking_warrior],
         quest_name=None,
         quest_loot=0,
         month=3,
@@ -527,10 +529,10 @@ def test_handle_faction_wins_skirmish_without_a_quest_contract():
 @pytest.mark.django_db
 def test_handle_finish_round_leaves_an_undecided_skirmish_without_a_victor():
     skirmish = SkirmishFactory()
-    player_warrior = WarriorFactory(faction=skirmish.player_faction)
-    enemy_warrior = WarriorFactory(faction=skirmish.non_player_faction)
-    skirmish.player_warriors.add(player_warrior)
-    skirmish.non_player_warriors.add(enemy_warrior)
+    attacking_warrior = WarriorFactory(faction=skirmish.attacking_faction)
+    enemy_warrior = WarriorFactory(faction=skirmish.defending_faction)
+    skirmish.attacking_warriors.add(attacking_warrior)
+    skirmish.defending_warriors.add(enemy_warrior)
 
     result = handle_finish_round(context=FinishRound(skirmish=skirmish, month=3))
 
@@ -540,50 +542,50 @@ def test_handle_finish_round_leaves_an_undecided_skirmish_without_a_victor():
 
 
 @pytest.mark.django_db
-def test_handle_finish_round_declares_the_player_faction_the_victor():
+def test_handle_finish_round_declares_the_attacking_faction_the_victor():
     skirmish = SkirmishFactory()
-    player_warrior = WarriorFactory(faction=skirmish.player_faction)
+    attacking_warrior = WarriorFactory(faction=skirmish.attacking_faction)
     dead_enemy_warrior = WarriorFactory(
-        faction=skirmish.non_player_faction, condition=Warrior.ConditionChoices.CONDITION_DEAD
+        faction=skirmish.defending_faction, condition=Warrior.ConditionChoices.CONDITION_DEAD
     )
-    skirmish.player_warriors.add(player_warrior)
-    skirmish.non_player_warriors.add(dead_enemy_warrior)
+    skirmish.attacking_warriors.add(attacking_warrior)
+    skirmish.defending_warriors.add(dead_enemy_warrior)
 
     result = handle_finish_round(context=FinishRound(skirmish=skirmish, month=3))
 
-    assert result == RoundFinished(skirmish=skirmish, victor=skirmish.player_faction, month=3)
+    assert result == RoundFinished(skirmish=skirmish, victor=skirmish.attacking_faction, month=3)
 
 
 @pytest.mark.django_db
-def test_handle_finish_round_declares_the_non_player_faction_the_victor():
+def test_handle_finish_round_declares_the_defending_faction_the_victor():
     skirmish = SkirmishFactory()
-    unconscious_player_warrior = WarriorFactory(
-        faction=skirmish.player_faction, condition=Warrior.ConditionChoices.CONDITION_UNCONSCIOUS
+    unconscious_attacking_warrior = WarriorFactory(
+        faction=skirmish.attacking_faction, condition=Warrior.ConditionChoices.CONDITION_UNCONSCIOUS
     )
-    enemy_warrior = WarriorFactory(faction=skirmish.non_player_faction)
-    skirmish.player_warriors.add(unconscious_player_warrior)
-    skirmish.non_player_warriors.add(enemy_warrior)
+    enemy_warrior = WarriorFactory(faction=skirmish.defending_faction)
+    skirmish.attacking_warriors.add(unconscious_attacking_warrior)
+    skirmish.defending_warriors.add(enemy_warrior)
 
     result = handle_finish_round(context=FinishRound(skirmish=skirmish, month=3))
 
-    assert result == RoundFinished(skirmish=skirmish, victor=skirmish.non_player_faction, month=3)
+    assert result == RoundFinished(skirmish=skirmish, victor=skirmish.defending_faction, month=3)
 
 
 @pytest.mark.django_db
-def test_handle_finish_round_declares_the_player_faction_the_victor_on_a_mutual_wipeout():
+def test_handle_finish_round_declares_the_attacking_faction_the_victor_on_a_mutual_wipeout():
     """
-    Both sides going down in the same round is decided in the player's favour.
+    Both sides going down in the same round is decided in favour of the side that marched.
     """
     skirmish = SkirmishFactory()
-    dead_player_warrior = WarriorFactory(
-        faction=skirmish.player_faction, condition=Warrior.ConditionChoices.CONDITION_DEAD
+    dead_attacking_warrior = WarriorFactory(
+        faction=skirmish.attacking_faction, condition=Warrior.ConditionChoices.CONDITION_DEAD
     )
     dead_enemy_warrior = WarriorFactory(
-        faction=skirmish.non_player_faction, condition=Warrior.ConditionChoices.CONDITION_DEAD
+        faction=skirmish.defending_faction, condition=Warrior.ConditionChoices.CONDITION_DEAD
     )
-    skirmish.player_warriors.add(dead_player_warrior)
-    skirmish.non_player_warriors.add(dead_enemy_warrior)
+    skirmish.attacking_warriors.add(dead_attacking_warrior)
+    skirmish.defending_warriors.add(dead_enemy_warrior)
 
     result = handle_finish_round(context=FinishRound(skirmish=skirmish, month=3))
 
-    assert result == RoundFinished(skirmish=skirmish, victor=skirmish.player_faction, month=3)
+    assert result == RoundFinished(skirmish=skirmish, victor=skirmish.attacking_faction, month=3)

--- a/apps/skirmish/tests/handlers/commands/test_transaction.py
+++ b/apps/skirmish/tests/handlers/commands/test_transaction.py
@@ -12,13 +12,13 @@ from apps.skirmish.tests.factories.warrior import WarriorFactory
 @pytest.mark.django_db
 def test_handle_warrior_drops_silver_hands_the_rolled_amount_to_the_victor():
     skirmish = SkirmishFactory()
-    warrior = WarriorFactory(faction=skirmish.non_player_faction)
+    warrior = WarriorFactory(faction=skirmish.defending_faction)
 
     # Boundary randomness: the dropped amount is a gauss roll
     with mock.patch("apps.skirmish.handlers.commands.transaction.random.gauss", return_value=12.4):
         result = handle_warrior_drops_silver(
             context=WarriorDropsSilver(
-                skirmish=skirmish, warrior=warrior, gaining_faction=skirmish.player_faction, month=3
+                skirmish=skirmish, warrior=warrior, gaining_faction=skirmish.attacking_faction, month=3
             )
         )
 
@@ -26,7 +26,7 @@ def test_handle_warrior_drops_silver_hands_the_rolled_amount_to_the_victor():
         WarriorDroppedSilver(
             skirmish=skirmish,
             warrior=warrior,
-            gaining_faction=skirmish.player_faction,
+            gaining_faction=skirmish.attacking_faction,
             amount=12,
             month=3,
         )
@@ -36,13 +36,13 @@ def test_handle_warrior_drops_silver_hands_the_rolled_amount_to_the_victor():
 @pytest.mark.django_db
 def test_handle_warrior_drops_silver_drops_nothing_on_a_zero_roll():
     skirmish = SkirmishFactory()
-    warrior = WarriorFactory(faction=skirmish.non_player_faction)
+    warrior = WarriorFactory(faction=skirmish.defending_faction)
 
     # Boundary randomness: a negative roll is clamped to zero, which means no silver at all
     with mock.patch("apps.skirmish.handlers.commands.transaction.random.gauss", return_value=-3.0):
         result = handle_warrior_drops_silver(
             context=WarriorDropsSilver(
-                skirmish=skirmish, warrior=warrior, gaining_faction=skirmish.player_faction, month=3
+                skirmish=skirmish, warrior=warrior, gaining_faction=skirmish.attacking_faction, month=3
             )
         )
 

--- a/apps/skirmish/tests/handlers/commands/test_warrior.py
+++ b/apps/skirmish/tests/handlers/commands/test_warrior.py
@@ -33,25 +33,29 @@ from apps.skirmish.tests.factories.warrior import WarriorFactory
 @pytest.mark.django_db
 def test_handle_warrior_is_captured_hands_the_warrior_to_the_victor():
     skirmish = SkirmishFactory()
-    captured_warrior = WarriorFactory(faction=skirmish.non_player_faction)
+    captured_warrior = WarriorFactory(faction=skirmish.defending_faction)
 
     result = handle_warrior_is_captured(
-        context=CaptureWarrior(skirmish=skirmish, warrior=captured_warrior, capturing_faction=skirmish.player_faction)
+        context=CaptureWarrior(
+            skirmish=skirmish, warrior=captured_warrior, capturing_faction=skirmish.attacking_faction
+        )
     )
 
     assert result == WarriorWasCaptured(
-        skirmish=skirmish, warrior=captured_warrior, capturing_faction=skirmish.player_faction
+        skirmish=skirmish, warrior=captured_warrior, capturing_faction=skirmish.attacking_faction
     )
-    assert list(skirmish.player_faction.captured_warriors.all()) == [captured_warrior]
+    assert list(skirmish.attacking_faction.captured_warriors.all()) == [captured_warrior]
 
 
 @pytest.mark.django_db
 def test_handle_warrior_is_captured_takes_the_warrior_out_of_his_faction():
     skirmish = SkirmishFactory()
-    captured_warrior = WarriorFactory(faction=skirmish.non_player_faction)
+    captured_warrior = WarriorFactory(faction=skirmish.defending_faction)
 
     handle_warrior_is_captured(
-        context=CaptureWarrior(skirmish=skirmish, warrior=captured_warrior, capturing_faction=skirmish.player_faction)
+        context=CaptureWarrior(
+            skirmish=skirmish, warrior=captured_warrior, capturing_faction=skirmish.attacking_faction
+        )
     )
 
     captured_warrior.refresh_from_db()
@@ -65,27 +69,27 @@ def test_handle_warrior_is_captured_leaves_an_existing_prisoner_where_he_is():
     one pass - so this runs twice for him. The second captor does not get to take him off the first.
     """
     skirmish = SkirmishFactory()
-    second_skirmish = SkirmishFactory(player_faction=skirmish.player_faction)
-    captured_warrior = WarriorFactory(faction=skirmish.non_player_faction)
-    skirmish.player_faction.captured_warriors.add(captured_warrior)
+    second_skirmish = SkirmishFactory(attacking_faction=skirmish.attacking_faction)
+    captured_warrior = WarriorFactory(faction=skirmish.defending_faction)
+    skirmish.attacking_faction.captured_warriors.add(captured_warrior)
 
     result = handle_warrior_is_captured(
         context=CaptureWarrior(
             skirmish=second_skirmish,
             warrior=captured_warrior,
-            capturing_faction=second_skirmish.non_player_faction,
+            capturing_faction=second_skirmish.defending_faction,
         )
     )
 
     assert result is None
-    assert list(second_skirmish.non_player_faction.captured_warriors.all()) == []
+    assert list(second_skirmish.defending_faction.captured_warriors.all()) == []
 
 
 @pytest.mark.django_db
 def test_handle_reduce_warrior_health_kills_the_warrior():
     skirmish = SkirmishFactory()
-    attacker = WarriorFactory(faction=skirmish.player_faction)
-    defender = WarriorFactory(faction=skirmish.non_player_faction, current_health=20, max_health=20)
+    attacker = WarriorFactory(faction=skirmish.attacking_faction)
+    defender = WarriorFactory(faction=skirmish.defending_faction, current_health=20, max_health=20)
 
     result = handle_reduce_warrior_health(
         context=ReduceHealth(skirmish=skirmish, warrior=defender, attacker=attacker, lost_health=24)
@@ -99,8 +103,8 @@ def test_handle_reduce_warrior_health_kills_the_warrior():
 @pytest.mark.django_db
 def test_handle_reduce_warrior_health_incapacitates_the_warrior():
     skirmish = SkirmishFactory()
-    attacker = WarriorFactory(faction=skirmish.player_faction)
-    defender = WarriorFactory(faction=skirmish.non_player_faction, current_health=20, max_health=20)
+    attacker = WarriorFactory(faction=skirmish.attacking_faction)
+    defender = WarriorFactory(faction=skirmish.defending_faction, current_health=20, max_health=20)
 
     result = handle_reduce_warrior_health(
         context=ReduceHealth(skirmish=skirmish, warrior=defender, attacker=attacker, lost_health=23)
@@ -114,8 +118,8 @@ def test_handle_reduce_warrior_health_incapacitates_the_warrior():
 @pytest.mark.django_db
 def test_handle_reduce_warrior_health_leaves_a_surviving_warrior_healthy():
     skirmish = SkirmishFactory()
-    attacker = WarriorFactory(faction=skirmish.player_faction)
-    defender = WarriorFactory(faction=skirmish.non_player_faction, current_health=20, max_health=20)
+    attacker = WarriorFactory(faction=skirmish.attacking_faction)
+    defender = WarriorFactory(faction=skirmish.defending_faction, current_health=20, max_health=20)
 
     result = handle_reduce_warrior_health(
         context=ReduceHealth(skirmish=skirmish, warrior=defender, attacker=attacker, lost_health=5)
@@ -130,7 +134,7 @@ def test_handle_reduce_warrior_health_leaves_a_surviving_warrior_healthy():
 def test_handle_warrior_losing_morale_ignores_an_unconscious_warrior():
     skirmish = SkirmishFactory()
     warrior = WarriorFactory(
-        faction=skirmish.player_faction,
+        faction=skirmish.attacking_faction,
         condition=Warrior.ConditionChoices.CONDITION_UNCONSCIOUS,
         current_morale=20,
         max_morale=20,
@@ -144,7 +148,7 @@ def test_handle_warrior_losing_morale_ignores_an_unconscious_warrior():
 @pytest.mark.django_db
 def test_handle_warrior_losing_morale_makes_the_warrior_flee_without_morale_left():
     skirmish = SkirmishFactory()
-    warrior = WarriorFactory(faction=skirmish.player_faction, current_morale=5, max_morale=20)
+    warrior = WarriorFactory(faction=skirmish.attacking_faction, current_morale=5, max_morale=20)
 
     result = handle_warrior_losing_morale(context=ReduceMorale(skirmish=skirmish, warrior=warrior, lost_morale=5))
 
@@ -159,7 +163,7 @@ def test_handle_warrior_losing_morale_makes_the_warrior_flee_without_morale_left
 @pytest.mark.django_db
 def test_handle_warrior_losing_morale_keeps_a_warrior_with_morale_left_fighting():
     skirmish = SkirmishFactory()
-    warrior = WarriorFactory(faction=skirmish.player_faction, current_morale=20, max_morale=20)
+    warrior = WarriorFactory(faction=skirmish.attacking_faction, current_morale=20, max_morale=20)
 
     result = handle_warrior_losing_morale(context=ReduceMorale(skirmish=skirmish, warrior=warrior, lost_morale=2))
 
@@ -171,7 +175,7 @@ def test_handle_warrior_losing_morale_keeps_a_warrior_with_morale_left_fighting(
 @pytest.mark.django_db
 def test_handle_warrior_losing_morale_stays_silent_without_a_morale_loss():
     skirmish = SkirmishFactory()
-    warrior = WarriorFactory(faction=skirmish.player_faction, current_morale=20, max_morale=20)
+    warrior = WarriorFactory(faction=skirmish.attacking_faction, current_morale=20, max_morale=20)
 
     result = handle_warrior_losing_morale(context=ReduceMorale(skirmish=skirmish, warrior=warrior, lost_morale=0))
 
@@ -179,11 +183,11 @@ def test_handle_warrior_losing_morale_stays_silent_without_a_morale_loss():
 
 
 @pytest.mark.django_db
-def test_handle_reduce_morale_of_remaining_warriors_hits_the_comrades_of_a_player_warrior():
+def test_handle_reduce_morale_of_remaining_warriors_hits_the_comrades_of_an_attacking_warrior():
     skirmish = SkirmishFactory()
-    fleeing_warrior = WarriorFactory(faction=skirmish.player_faction, max_morale=20)
-    comrade = WarriorFactory(faction=skirmish.player_faction)
-    skirmish.player_warriors.add(fleeing_warrior, comrade)
+    fleeing_warrior = WarriorFactory(faction=skirmish.attacking_faction, max_morale=20)
+    comrade = WarriorFactory(faction=skirmish.attacking_faction)
+    skirmish.attacking_warriors.add(fleeing_warrior, comrade)
 
     result = handle_reduce_morale_of_remaining_warriors(
         context=ReduceMoraleOfRemainingWarriors(skirmish=skirmish, warrior=fleeing_warrior)
@@ -195,9 +199,9 @@ def test_handle_reduce_morale_of_remaining_warriors_hits_the_comrades_of_a_playe
 @pytest.mark.django_db
 def test_handle_reduce_morale_of_remaining_warriors_hits_the_comrades_of_an_enemy_warrior():
     skirmish = SkirmishFactory()
-    incapacitated_warrior = WarriorFactory(faction=skirmish.non_player_faction, max_morale=20)
-    comrade = WarriorFactory(faction=skirmish.non_player_faction)
-    skirmish.non_player_warriors.add(incapacitated_warrior, comrade)
+    incapacitated_warrior = WarriorFactory(faction=skirmish.defending_faction, max_morale=20)
+    comrade = WarriorFactory(faction=skirmish.defending_faction)
+    skirmish.defending_warriors.add(incapacitated_warrior, comrade)
 
     result = handle_reduce_morale_of_remaining_warriors(
         context=ReduceMoraleOfRemainingWarriors(skirmish=skirmish, warrior=incapacitated_warrior)
@@ -209,8 +213,8 @@ def test_handle_reduce_morale_of_remaining_warriors_hits_the_comrades_of_an_enem
 @pytest.mark.django_db
 def test_handle_reduce_morale_of_remaining_warriors_skips_the_warrior_himself():
     skirmish = SkirmishFactory()
-    killed_warrior = WarriorFactory(faction=skirmish.player_faction, max_morale=20)
-    skirmish.player_warriors.add(killed_warrior)
+    killed_warrior = WarriorFactory(faction=skirmish.attacking_faction, max_morale=20)
+    skirmish.attacking_warriors.add(killed_warrior)
 
     result = handle_reduce_morale_of_remaining_warriors(
         context=ReduceMoraleOfRemainingWarriors(skirmish=skirmish, warrior=killed_warrior)
@@ -222,7 +226,7 @@ def test_handle_reduce_morale_of_remaining_warriors_skips_the_warrior_himself():
 @pytest.mark.django_db
 def test_handle_warrior_increasing_morale_adds_the_gained_points():
     skirmish = SkirmishFactory()
-    warrior = WarriorFactory(faction=skirmish.player_faction, current_morale=10, max_morale=20)
+    warrior = WarriorFactory(faction=skirmish.attacking_faction, current_morale=10, max_morale=20)
 
     result = handle_warrior_increasing_morale(
         context=IncreaseMorale(skirmish=skirmish, warrior=warrior, increased_morale=5)
@@ -236,7 +240,7 @@ def test_handle_warrior_increasing_morale_adds_the_gained_points():
 @pytest.mark.django_db
 def test_handle_warrior_increasing_experience_adds_the_gained_points():
     skirmish = SkirmishFactory()
-    warrior = WarriorFactory(faction=skirmish.player_faction, experience=100)
+    warrior = WarriorFactory(faction=skirmish.attacking_faction, experience=100)
 
     result = handle_warrior_increasing_experience(
         context=IncreaseExperience(skirmish=skirmish, warrior=warrior, increased_experience=25)

--- a/apps/skirmish/tests/handlers/events/test_item.py
+++ b/apps/skirmish/tests/handlers/events/test_item.py
@@ -12,10 +12,10 @@ from apps.skirmish.tests.factories.warrior import WarriorFactory
 @pytest.mark.django_db
 def test_handle_distribute_loot_hands_items_and_silver_of_every_incapacitated_warrior_to_the_victor():
     skirmish = SkirmishFactory()
-    skirmish.victorious_faction = skirmish.player_faction
+    skirmish.victorious_faction = skirmish.attacking_faction
     skirmish.save()
     dead_enemy_warrior = WarriorFactory(
-        faction=skirmish.non_player_faction, condition=Warrior.ConditionChoices.CONDITION_DEAD
+        faction=skirmish.defending_faction, condition=Warrior.ConditionChoices.CONDITION_DEAD
     )
 
     result = handle_distribute_loot(
@@ -31,11 +31,11 @@ def test_handle_distribute_loot_hands_items_and_silver_of_every_incapacitated_wa
     )
 
     assert result == [
-        WarriorDropsLoot(skirmish=skirmish, warrior=dead_enemy_warrior, new_owner=skirmish.player_faction),
+        WarriorDropsLoot(skirmish=skirmish, warrior=dead_enemy_warrior, new_owner=skirmish.attacking_faction),
         WarriorDropsSilver(
             skirmish=skirmish,
             warrior=dead_enemy_warrior,
-            gaining_faction=skirmish.player_faction,
+            gaining_faction=skirmish.attacking_faction,
             month=3,
         ),
     ]

--- a/apps/skirmish/tests/handlers/events/test_savegame.py
+++ b/apps/skirmish/tests/handlers/events/test_savegame.py
@@ -14,14 +14,14 @@ def test_handle_win_open_skirmishes_when_the_game_ends_gives_a_won_game_to_the_p
 
     result = handle_win_open_skirmishes_when_the_game_ends(
         context=SavegameEnded(
-            savegame=SavegameFactory.build(),
+            savegame=SavegameFactory.build(player_faction=skirmish.attacking_faction),
             outcome=Savegame.OutcomeChoices.OUTCOME_WON,
             open_skirmish_list=[skirmish],
             month=3,
         )
     )
 
-    assert result == [WinSkirmish(skirmish=skirmish, victorious_faction=skirmish.player_faction, month=3)]
+    assert result == [WinSkirmish(skirmish=skirmish, victorious_faction=skirmish.attacking_faction, month=3)]
 
 
 @pytest.mark.django_db
@@ -30,14 +30,36 @@ def test_handle_win_open_skirmishes_when_the_game_ends_gives_a_lost_game_to_the_
 
     result = handle_win_open_skirmishes_when_the_game_ends(
         context=SavegameEnded(
-            savegame=SavegameFactory.build(),
+            savegame=SavegameFactory.build(player_faction=skirmish.attacking_faction),
             outcome=Savegame.OutcomeChoices.OUTCOME_LOST,
             open_skirmish_list=[skirmish],
             month=3,
         )
     )
 
-    assert result == [WinSkirmish(skirmish=skirmish, victorious_faction=skirmish.non_player_faction, month=3)]
+    assert result == [WinSkirmish(skirmish=skirmish, victorious_faction=skirmish.defending_faction, month=3)]
+
+
+@pytest.mark.django_db
+def test_handle_win_open_skirmishes_when_the_game_ends_gives_a_won_game_to_the_defending_player():
+    """
+    The player is on the defending side here, so a won game has to go to the defender.
+
+    Reading the player off side one would have handed the fight to the faction that marched against
+    him - the reason this asks the savegame rather than the skirmish row.
+    """
+    skirmish = SkirmishFactory()
+
+    result = handle_win_open_skirmishes_when_the_game_ends(
+        context=SavegameEnded(
+            savegame=SavegameFactory.build(player_faction=skirmish.defending_faction),
+            outcome=Savegame.OutcomeChoices.OUTCOME_WON,
+            open_skirmish_list=[skirmish],
+            month=3,
+        )
+    )
+
+    assert result == [WinSkirmish(skirmish=skirmish, victorious_faction=skirmish.defending_faction, month=3)]
 
 
 def test_handle_win_open_skirmishes_when_the_game_ends_without_an_open_fight():

--- a/apps/skirmish/tests/handlers/events/test_skirmish.py
+++ b/apps/skirmish/tests/handlers/events/test_skirmish.py
@@ -39,9 +39,9 @@ def test_handle_create_skirmish_for_attack_maps_to_the_command():
 def test_handle_round_finished_wins_the_skirmish_for_the_victor():
     skirmish = SkirmishFactory()
 
-    result = handle_round_finished(context=RoundFinished(skirmish=skirmish, victor=skirmish.player_faction, month=3))
+    result = handle_round_finished(context=RoundFinished(skirmish=skirmish, victor=skirmish.attacking_faction, month=3))
 
-    assert result == WinSkirmish(skirmish=skirmish, victorious_faction=skirmish.player_faction, month=3)
+    assert result == WinSkirmish(skirmish=skirmish, victorious_faction=skirmish.attacking_faction, month=3)
 
 
 @pytest.mark.django_db

--- a/apps/skirmish/tests/handlers/events/test_warrior.py
+++ b/apps/skirmish/tests/handlers/events/test_warrior.py
@@ -58,7 +58,7 @@ def test_handle_morale_drop_on_faction_on_warrior_is_out_of_fight_for_a_fleeing_
     database access here.
     """
     skirmish = SkirmishFactory.build()
-    fleeing_warrior = WarriorFactory.build(faction=skirmish.player_faction)
+    fleeing_warrior = WarriorFactory.build(faction=skirmish.attacking_faction)
 
     result = handle_morale_drop_on_faction_on_warrior_is_out_of_fight(
         context=WarriorHasFled(skirmish=skirmish, warrior=fleeing_warrior)
@@ -69,8 +69,8 @@ def test_handle_morale_drop_on_faction_on_warrior_is_out_of_fight_for_a_fleeing_
 
 def test_handle_morale_drop_on_faction_on_warrior_is_out_of_fight_for_an_incapacitated_warrior():
     skirmish = SkirmishFactory.build()
-    incapacitated_warrior = WarriorFactory.build(faction=skirmish.non_player_faction)
-    attacker = WarriorFactory.build(faction=skirmish.player_faction)
+    incapacitated_warrior = WarriorFactory.build(faction=skirmish.defending_faction)
+    attacker = WarriorFactory.build(faction=skirmish.attacking_faction)
 
     result = handle_morale_drop_on_faction_on_warrior_is_out_of_fight(
         context=WarriorWasIncapacitated(skirmish=skirmish, warrior=incapacitated_warrior, by_warrior=attacker)
@@ -81,8 +81,8 @@ def test_handle_morale_drop_on_faction_on_warrior_is_out_of_fight_for_an_incapac
 
 def test_handle_morale_drop_on_faction_on_warrior_is_out_of_fight_for_a_killed_warrior():
     skirmish = SkirmishFactory.build()
-    killed_warrior = WarriorFactory.build(faction=skirmish.player_faction)
-    killer = WarriorFactory.build(faction=skirmish.non_player_faction)
+    killed_warrior = WarriorFactory.build(faction=skirmish.attacking_faction)
+    killer = WarriorFactory.build(faction=skirmish.defending_faction)
 
     result = handle_morale_drop_on_faction_on_warrior_is_out_of_fight(
         context=WarriorWasKilled(skirmish=skirmish, warrior=killed_warrior, by_warrior=killer)
@@ -96,8 +96,8 @@ def test_handle_experience_gain_on_warrior_incapacitation_for_an_incapacitated_w
     One test per registered message: the handler is registered for two of them.
     """
     skirmish = SkirmishFactory.build()
-    incapacitated_warrior = WarriorFactory.build(faction=skirmish.non_player_faction)
-    attacker = WarriorFactory.build(faction=skirmish.player_faction)
+    incapacitated_warrior = WarriorFactory.build(faction=skirmish.defending_faction)
+    attacker = WarriorFactory.build(faction=skirmish.attacking_faction)
 
     result = handle_experience_gain_on_warrior_incapacitation(
         context=WarriorWasIncapacitated(skirmish=skirmish, warrior=incapacitated_warrior, by_warrior=attacker)
@@ -108,8 +108,8 @@ def test_handle_experience_gain_on_warrior_incapacitation_for_an_incapacitated_w
 
 def test_handle_experience_gain_on_warrior_incapacitation_for_a_killed_warrior():
     skirmish = SkirmishFactory.build()
-    killed_warrior = WarriorFactory.build(faction=skirmish.non_player_faction)
-    killer = WarriorFactory.build(faction=skirmish.player_faction)
+    killed_warrior = WarriorFactory.build(faction=skirmish.defending_faction)
+    killer = WarriorFactory.build(faction=skirmish.attacking_faction)
 
     result = handle_experience_gain_on_warrior_incapacitation(
         context=WarriorWasKilled(skirmish=skirmish, warrior=killed_warrior, by_warrior=killer)
@@ -121,8 +121,8 @@ def test_handle_experience_gain_on_warrior_incapacitation_for_a_killed_warrior()
 @pytest.mark.django_db
 def test_handle_morale_change_on_warrior_defends_all_damage_rewards_a_real_defence():
     skirmish = SkirmishFactory()
-    attacker = WarriorFactory(faction=skirmish.player_faction)
-    defender = WarriorFactory(faction=skirmish.non_player_faction, current_morale=10, max_morale=20)
+    attacker = WarriorFactory(faction=skirmish.attacking_faction)
+    defender = WarriorFactory(faction=skirmish.defending_faction, current_morale=10, max_morale=20)
 
     result = handle_morale_change_on_warrior_defends_all_damage(
         context=WarriorDefendedAllDamage(
@@ -145,8 +145,8 @@ def test_handle_morale_change_on_warrior_defends_all_damage_wears_down_a_turtle(
     it - otherwise nothing moves the morale of a warrior nobody can hurt.
     """
     skirmish = SkirmishFactory()
-    attacker = WarriorFactory(faction=skirmish.player_faction)
-    defender = WarriorFactory(faction=skirmish.non_player_faction, current_morale=10, max_morale=20)
+    attacker = WarriorFactory(faction=skirmish.attacking_faction)
+    defender = WarriorFactory(faction=skirmish.defending_faction, current_morale=10, max_morale=20)
 
     result = handle_morale_change_on_warrior_defends_all_damage(
         context=WarriorDefendedAllDamage(
@@ -170,8 +170,8 @@ def test_handle_morale_change_on_warrior_defends_all_damage_rewards_nothing_on_a
     point of morale is not handed one.
     """
     skirmish = SkirmishFactory()
-    attacker = WarriorFactory(faction=skirmish.player_faction)
-    defender = WarriorFactory(faction=skirmish.non_player_faction, current_morale=4, max_morale=4)
+    attacker = WarriorFactory(faction=skirmish.attacking_faction)
+    defender = WarriorFactory(faction=skirmish.defending_faction, current_morale=4, max_morale=4)
 
     result = handle_morale_change_on_warrior_defends_all_damage(
         context=WarriorDefendedAllDamage(
@@ -194,8 +194,8 @@ def test_handle_morale_change_on_warrior_defends_all_damage_always_costs_at_leas
     unwinnable fight all over again.
     """
     skirmish = SkirmishFactory()
-    attacker = WarriorFactory(faction=skirmish.player_faction)
-    defender = WarriorFactory(faction=skirmish.non_player_faction, current_morale=4, max_morale=4)
+    attacker = WarriorFactory(faction=skirmish.attacking_faction)
+    defender = WarriorFactory(faction=skirmish.defending_faction, current_morale=4, max_morale=4)
 
     result = handle_morale_change_on_warrior_defends_all_damage(
         context=WarriorDefendedAllDamage(
@@ -214,9 +214,9 @@ def test_handle_morale_change_on_warrior_defends_all_damage_always_costs_at_leas
 @pytest.mark.django_db
 def test_handle_capture_unconscious_warriors_captures_every_defeated_warrior():
     skirmish = SkirmishFactory()
-    skirmish.victorious_faction = skirmish.player_faction
+    skirmish.victorious_faction = skirmish.attacking_faction
     skirmish.save()
-    unconscious_enemy_warrior = WarriorFactory(faction=skirmish.non_player_faction)
+    unconscious_enemy_warrior = WarriorFactory(faction=skirmish.defending_faction)
 
     result = handle_capture_unconscious_warriors(
         context=SkirmishFinished(
@@ -234,7 +234,7 @@ def test_handle_capture_unconscious_warriors_captures_every_defeated_warrior():
         CaptureWarrior(
             skirmish=skirmish,
             warrior=unconscious_enemy_warrior,
-            capturing_faction=skirmish.player_faction,
+            capturing_faction=skirmish.attacking_faction,
         )
     ]
 
@@ -261,21 +261,21 @@ def test_handle_capture_unconscious_warriors_captures_nobody_without_defeated_wa
 @pytest.mark.django_db
 def test_handle_experience_gain_after_battle_for_victor_rewards_every_surviving_warrior():
     skirmish = SkirmishFactory()
-    healthy_player_warrior = WarriorFactory(faction=skirmish.player_faction)
+    healthy_attacking_warrior = WarriorFactory(faction=skirmish.attacking_faction)
 
     result = handle_experience_gain_after_battle_for_victor(
         context=SkirmishFinished(
             skirmish=skirmish,
             incapacitated_warriors=[],
             defeated_unconscious_warriors=[],
-            victorious_healthy_warriors=[healthy_player_warrior],
+            victorious_healthy_warriors=[healthy_attacking_warrior],
             quest_name="Raid",
             quest_loot=250,
             month=3,
         )
     )
 
-    assert result == [IncreaseExperience(skirmish=skirmish, warrior=healthy_player_warrior, increased_experience=10)]
+    assert result == [IncreaseExperience(skirmish=skirmish, warrior=healthy_attacking_warrior, increased_experience=10)]
 
 
 @pytest.mark.django_db

--- a/apps/skirmish/tests/management/commands/test_reset_skirmish.py
+++ b/apps/skirmish/tests/management/commands/test_reset_skirmish.py
@@ -14,20 +14,20 @@ def fought_skirmish(db) -> Skirmish:
     A skirmish in the state the developer tool is meant to undo: fought, decided and logged.
     """
     skirmish = SkirmishFactory(current_round=4)
-    skirmish.victorious_faction = skirmish.player_faction
+    skirmish.victorious_faction = skirmish.attacking_faction
     skirmish.save()
 
-    skirmish.player_warriors.add(
+    skirmish.attacking_warriors.add(
         WarriorFactory(
-            faction=skirmish.player_faction,
+            faction=skirmish.attacking_faction,
             current_health=3,
             current_morale=1,
             condition=Warrior.ConditionChoices.CONDITION_FLEEING,
         )
     )
-    skirmish.non_player_warriors.add(
+    skirmish.defending_warriors.add(
         WarriorFactory(
-            faction=skirmish.non_player_faction,
+            faction=skirmish.defending_faction,
             current_health=-2,
             current_morale=0,
             condition=Warrior.ConditionChoices.CONDITION_UNCONSCIOUS,
@@ -50,8 +50,8 @@ def test_reset_skirmish_heals_every_participant(fought_skirmish):
 
     healed_warriors = Warrior.objects.filter(
         id__in=(
-            fought_skirmish.player_warriors.values_list("id", flat=True).union(
-                fought_skirmish.non_player_warriors.values_list("id", flat=True)
+            fought_skirmish.attacking_warriors.values_list("id", flat=True).union(
+                fought_skirmish.defending_warriors.values_list("id", flat=True)
             )
         )
     )
@@ -63,12 +63,12 @@ def test_reset_skirmish_heals_every_participant(fought_skirmish):
 
 
 def test_reset_skirmish_releases_the_captives(fought_skirmish):
-    captured_warrior = WarriorFactory(savegame=fought_skirmish.player_faction.savegame)
-    fought_skirmish.player_faction.captured_warriors.add(captured_warrior)
+    captured_warrior = WarriorFactory(savegame=fought_skirmish.attacking_faction.savegame)
+    fought_skirmish.attacking_faction.captured_warriors.add(captured_warrior)
 
     call_command("reset_skirmish", fought_skirmish.id)
 
-    assert list(fought_skirmish.player_faction.captured_warriors.all()) == []
+    assert list(fought_skirmish.attacking_faction.captured_warriors.all()) == []
 
 
 def test_reset_skirmish_clears_the_battle_history(fought_skirmish):

--- a/apps/skirmish/tests/managers/test_warrior.py
+++ b/apps/skirmish/tests/managers/test_warrior.py
@@ -63,8 +63,8 @@ def test_exclude_currently_busy_drops_a_warrior_who_fought_this_month():
     Every warrior fights once a month, so a decided fight still uses the month up.
     """
     warrior = WarriorFactory()
-    skirmish = SkirmishFactory(player_faction=warrior.faction, victorious_faction=warrior.faction, month=3)
-    skirmish.player_warriors.add(warrior)
+    skirmish = SkirmishFactory(attacking_faction=warrior.faction, victorious_faction=warrior.faction, month=3)
+    skirmish.attacking_warriors.add(warrior)
 
     result = Warrior.objects.exclude_currently_busy(month=3)
 
@@ -78,8 +78,8 @@ def test_exclude_currently_busy_drops_a_warrior_still_in_an_undecided_fight():
     again next month while he is still standing on that roster.
     """
     warrior = WarriorFactory()
-    skirmish = SkirmishFactory(player_faction=warrior.faction, month=2)
-    skirmish.player_warriors.add(warrior)
+    skirmish = SkirmishFactory(attacking_faction=warrior.faction, month=2)
+    skirmish.attacking_warriors.add(warrior)
 
     result = Warrior.objects.exclude_currently_busy(month=3)
 
@@ -89,8 +89,8 @@ def test_exclude_currently_busy_drops_a_warrior_still_in_an_undecided_fight():
 @pytest.mark.django_db
 def test_exclude_currently_busy_keeps_a_warrior_whose_last_fight_is_over():
     warrior = WarriorFactory()
-    skirmish = SkirmishFactory(player_faction=warrior.faction, victorious_faction=warrior.faction, month=2)
-    skirmish.player_warriors.add(warrior)
+    skirmish = SkirmishFactory(attacking_faction=warrior.faction, victorious_faction=warrior.faction, month=2)
+    skirmish.attacking_warriors.add(warrior)
 
     result = Warrior.objects.exclude_currently_busy(month=3)
 
@@ -98,19 +98,19 @@ def test_exclude_currently_busy_keeps_a_warrior_whose_last_fight_is_over():
 
 
 @pytest.mark.django_db
-def test_exclude_currently_busy_drops_a_warrior_who_fought_on_the_opposing_side():
+def test_exclude_currently_busy_drops_a_warrior_who_fought_on_the_defending_side():
     """
     Which side of the row a warrior stands on is a property of the skirmish, not of him - a captive
     who has since changed banners fought all the same.
     """
     warrior = WarriorFactory()
     skirmish = SkirmishFactory(
-        non_player_faction=warrior.faction,
-        player_faction=FactionFactory(savegame=warrior.savegame),
+        defending_faction=warrior.faction,
+        attacking_faction=FactionFactory(savegame=warrior.savegame),
         victorious_faction=warrior.faction,
         month=3,
     )
-    skirmish.non_player_warriors.add(warrior)
+    skirmish.defending_warriors.add(warrior)
 
     result = Warrior.objects.exclude_currently_busy(month=3)
 

--- a/apps/skirmish/tests/services/actions/test_defensive_stance.py
+++ b/apps/skirmish/tests/services/actions/test_defensive_stance.py
@@ -17,7 +17,7 @@ def test_get_pair_matching_points_never_makes_the_warrior_the_attacker():
 @pytest.mark.django_db
 def test_get_attack_value_never_deals_damage():
     skirmish = SkirmishFactory()
-    warrior = WarriorFactory(faction=skirmish.player_faction)
+    warrior = WarriorFactory(faction=skirmish.attacking_faction)
     service = DefensiveStanceService(skirmish=skirmish, warrior=warrior)
 
     result = service.get_attack_value()
@@ -29,7 +29,7 @@ def test_get_attack_value_never_deals_damage():
 @pytest.mark.django_db
 def test_get_defense_value_doubles_the_defense():
     skirmish = SkirmishFactory()
-    warrior = WarriorFactory(faction=skirmish.player_faction)
+    warrior = WarriorFactory(faction=skirmish.attacking_faction)
     service = DefensiveStanceService(skirmish=skirmish, warrior=warrior)
 
     # Patched at the boundary: the die behind "roll_defense()"

--- a/apps/skirmish/tests/services/actions/test_fast_attack.py
+++ b/apps/skirmish/tests/services/actions/test_fast_attack.py
@@ -17,7 +17,7 @@ def test_get_pair_matching_points_doubles_the_base_points():
 @pytest.mark.django_db
 def test_get_attack_value_halves_the_damage():
     skirmish = SkirmishFactory()
-    warrior = WarriorFactory(faction=skirmish.player_faction, strength=20)
+    warrior = WarriorFactory(faction=skirmish.attacking_faction, strength=20)
     service = FastAttackService(skirmish=skirmish, warrior=warrior)
 
     # Patched at the boundary: the die behind "roll_attack()"

--- a/apps/skirmish/tests/services/actions/test_risky_attack.py
+++ b/apps/skirmish/tests/services/actions/test_risky_attack.py
@@ -11,7 +11,7 @@ from apps.skirmish.tests.factories.warrior import WarriorFactory
 @pytest.mark.django_db
 def test_get_attack_value_doubles_the_damage_on_a_hit():
     skirmish = SkirmishFactory()
-    warrior = WarriorFactory(faction=skirmish.player_faction, strength=10)
+    warrior = WarriorFactory(faction=skirmish.attacking_faction, strength=10)
     service = RiskyAttackService(skirmish=skirmish, warrior=warrior)
 
     # Patched at the boundary: the coin flip deciding hit or miss, and the die behind "roll_attack()"
@@ -28,7 +28,7 @@ def test_get_attack_value_doubles_the_damage_on_a_hit():
 @pytest.mark.django_db
 def test_get_attack_value_deals_nothing_on_a_miss():
     skirmish = SkirmishFactory()
-    warrior = WarriorFactory(faction=skirmish.player_faction, strength=10)
+    warrior = WarriorFactory(faction=skirmish.attacking_faction, strength=10)
     service = RiskyAttackService(skirmish=skirmish, warrior=warrior)
 
     with mock.patch("apps.skirmish.services.actions.risky_attack.random.getrandbits", return_value=0):

--- a/apps/skirmish/tests/services/generators/skirmish/test_base.py
+++ b/apps/skirmish/tests/services/generators/skirmish/test_base.py
@@ -7,20 +7,20 @@ from apps.skirmish.tests.factories.warrior import WarriorFactory
 
 @pytest.mark.django_db
 def test_process_sets_up_both_sides():
-    player_faction = FactionFactory()
-    enemy_faction = FactionFactory(savegame=player_faction.savegame)
-    player_warrior = WarriorFactory(faction=player_faction)
+    attacking_faction = FactionFactory()
+    enemy_faction = FactionFactory(savegame=attacking_faction.savegame)
+    attacking_warrior = WarriorFactory(faction=attacking_faction)
     enemy_warrior = WarriorFactory(faction=enemy_faction)
 
     result = BaseSkirmishGenerator(
         name="Attack on Wessex",
-        warriors_faction_1=[player_warrior],
+        warriors_faction_1=[attacking_warrior],
         warriors_faction_2=[enemy_warrior],
         month=7,
     ).process()
 
     assert result.month == 7
-    assert list(result.player_warriors.all()) == [player_warrior]
+    assert list(result.attacking_warriors.all()) == [attacking_warrior]
 
 
 @pytest.mark.django_db
@@ -43,11 +43,11 @@ def test_process_without_a_defending_side():
     """
     Says which side is missing instead of dying on the IndexError three lines further down.
     """
-    player_faction = FactionFactory()
+    attacking_faction = FactionFactory()
 
     generator = BaseSkirmishGenerator(
         name="Attack on Wessex",
-        warriors_faction_1=[WarriorFactory(faction=player_faction)],
+        warriors_faction_1=[WarriorFactory(faction=attacking_faction)],
         warriors_faction_2=[],
         month=7,
     )

--- a/apps/skirmish/tests/services/skirmish/test_damage.py
+++ b/apps/skirmish/tests/services/skirmish/test_damage.py
@@ -13,9 +13,9 @@ def damage_service(db) -> SkirmishDamageService:
 
     return SkirmishDamageService(
         skirmish=skirmish,
-        attacker=WarriorFactory(faction=skirmish.player_faction),
+        attacker=WarriorFactory(faction=skirmish.attacking_faction),
         attacker_action=SkirmishActionChoices.SIMPLE_ATTACK,
-        defender=WarriorFactory(faction=skirmish.non_player_faction),
+        defender=WarriorFactory(faction=skirmish.defending_faction),
         defender_action=SkirmishActionChoices.SIMPLE_ATTACK,
     )
 

--- a/apps/skirmish/tests/test_context_processors.py
+++ b/apps/skirmish/tests/test_context_processors.py
@@ -8,7 +8,7 @@ from apps.skirmish.tests.factories.skirmish import SkirmishFactory
 @pytest.mark.django_db
 def test_get_open_skirmishes_returns_the_unresolved_skirmishes(rf, user):
     savegame = SavegameFactory(created_by=user)
-    skirmish = SkirmishFactory(player_faction__savegame=savegame, victorious_faction=None)
+    skirmish = SkirmishFactory(attacking_faction__savegame=savegame, victorious_faction=None)
     request = rf.get("/")
     request.user = user
 

--- a/apps/skirmish/tests/test_flows.py
+++ b/apps/skirmish/tests/test_flows.py
@@ -24,9 +24,9 @@ def test_a_warrior_who_only_turtles_eventually_routs(queuebie_registry):
     turns into a rout, not how many rounds it took to get there.
     """
     skirmish = SkirmishFactory()
-    attacker = WarriorFactory(faction=skirmish.player_faction)
+    attacker = WarriorFactory(faction=skirmish.attacking_faction)
     exhausted_defender = WarriorFactory(
-        faction=skirmish.non_player_faction, current_morale=2, max_morale=20, current_health=3
+        faction=skirmish.defending_faction, current_morale=2, max_morale=20, current_health=3
     )
 
     handle_message(

--- a/apps/skirmish/tests/test_views.py
+++ b/apps/skirmish/tests/test_views.py
@@ -10,7 +10,7 @@ from apps.skirmish.tests.factories.warrior import WarriorFactory
 
 @pytest.mark.django_db
 def test_skirmish_list_view_lists_the_skirmishes_of_the_current_savegame(logged_in_client, current_savegame):
-    skirmish = SkirmishFactory(player_faction=current_savegame.player_faction)
+    skirmish = SkirmishFactory(attacking_faction=current_savegame.player_faction)
 
     response = logged_in_client.get(reverse("skirmish:skirmish-list-view"))
 
@@ -30,12 +30,26 @@ def test_skirmish_list_view_hides_a_skirmish_of_another_savegame(logged_in_clien
 
 @pytest.mark.django_db
 def test_skirmish_fight_view_shows_the_skirmish(logged_in_client, current_savegame):
-    skirmish = SkirmishFactory(player_faction=current_savegame.player_faction)
+    skirmish = SkirmishFactory(attacking_faction=current_savegame.player_faction)
 
     response = logged_in_client.get(reverse("skirmish:skirmish-fight-view", kwargs={"pk": skirmish.pk}))
 
     assert response.status_code == 200
     assert response.context["object"] == skirmish
+
+
+@pytest.mark.django_db
+def test_skirmish_fight_view_marks_which_side_the_player_holds(logged_in_client, current_savegame):
+    """
+    The two flags drive whether a side's warrior cards offer the human a skirmish action, so exactly
+    one of them may be True - here the player is the faction that marched.
+    """
+    skirmish = SkirmishFactory(attacking_faction=current_savegame.player_faction)
+
+    response = logged_in_client.get(reverse("skirmish:skirmish-fight-view", kwargs={"pk": skirmish.pk}))
+
+    assert response.context["attacker_is_player"] is True
+    assert response.context["defender_is_player"] is False
 
 
 @pytest.mark.django_db
@@ -49,8 +63,8 @@ def test_skirmish_fight_view_cannot_show_a_skirmish_of_another_savegame(logged_i
 
 @pytest.mark.django_db
 def test_skirmish_fight_view_sends_the_player_back_with_another_skirmish_running(logged_in_client, current_savegame):
-    skirmish = SkirmishFactory(player_faction=current_savegame.player_faction)
-    SkirmishFactory(player_faction=current_savegame.player_faction, current_round=2)
+    skirmish = SkirmishFactory(attacking_faction=current_savegame.player_faction)
+    SkirmishFactory(attacking_faction=current_savegame.player_faction, current_round=2)
 
     response = logged_in_client.get(reverse("skirmish:skirmish-fight-view", kwargs={"pk": skirmish.pk}))
 
@@ -67,19 +81,19 @@ def test_skirmish_finish_round_view_advances_the_round(logged_in_client, current
     deals at most 3 damage against 20 health, so both warriors stay healthy and only the round
     counter settles.
     """
-    skirmish = SkirmishFactory(player_faction=current_savegame.player_faction)
-    player_warrior = WarriorFactory(faction=skirmish.player_faction)
-    opposing_warrior = WarriorFactory(faction=skirmish.non_player_faction)
-    skirmish.player_warriors.add(player_warrior)
-    skirmish.non_player_warriors.add(opposing_warrior)
+    skirmish = SkirmishFactory(attacking_faction=current_savegame.player_faction)
+    player_warrior = WarriorFactory(faction=skirmish.attacking_faction)
+    opposing_warrior = WarriorFactory(faction=skirmish.defending_faction)
+    skirmish.attacking_warriors.add(player_warrior)
+    skirmish.defending_warriors.add(opposing_warrior)
 
     response = logged_in_client.post(
         reverse("skirmish:skirmish-finish-round-view", kwargs={"pk": skirmish.pk}),
         data={
-            "skirmish_participant[0][faction_id]": skirmish.player_faction_id,
+            "skirmish_participant[0][faction_id]": skirmish.attacking_faction_id,
             "skirmish_participant[0][warrior_id]": player_warrior.pk,
             "skirmish_participant[0][skirmish_action]": SkirmishActionChoices.SIMPLE_ATTACK,
-            "skirmish_participant[1][faction_id]": skirmish.non_player_faction_id,
+            "skirmish_participant[1][faction_id]": skirmish.defending_faction_id,
             "skirmish_participant[1][warrior_id]": opposing_warrior.pk,
             "skirmish_participant[1][skirmish_action]": SkirmishActionChoices.SIMPLE_ATTACK,
         },
@@ -94,18 +108,18 @@ def test_skirmish_finish_round_view_advances_the_round(logged_in_client, current
 @pytest.mark.django_db
 def test_skirmish_finish_round_view_cannot_finish_a_round_of_another_savegame(logged_in_client, current_savegame):
     other_skirmish = SkirmishFactory()
-    other_player_warrior = WarriorFactory(faction=other_skirmish.player_faction)
-    other_opposing_warrior = WarriorFactory(faction=other_skirmish.non_player_faction)
-    other_skirmish.player_warriors.add(other_player_warrior)
-    other_skirmish.non_player_warriors.add(other_opposing_warrior)
+    other_player_warrior = WarriorFactory(faction=other_skirmish.attacking_faction)
+    other_opposing_warrior = WarriorFactory(faction=other_skirmish.defending_faction)
+    other_skirmish.attacking_warriors.add(other_player_warrior)
+    other_skirmish.defending_warriors.add(other_opposing_warrior)
 
     response = logged_in_client.post(
         reverse("skirmish:skirmish-finish-round-view", kwargs={"pk": other_skirmish.pk}),
         data={
-            "skirmish_participant[0][faction_id]": other_skirmish.player_faction_id,
+            "skirmish_participant[0][faction_id]": other_skirmish.attacking_faction_id,
             "skirmish_participant[0][warrior_id]": other_player_warrior.pk,
             "skirmish_participant[0][skirmish_action]": SkirmishActionChoices.SIMPLE_ATTACK,
-            "skirmish_participant[1][faction_id]": other_skirmish.non_player_faction_id,
+            "skirmish_participant[1][faction_id]": other_skirmish.defending_faction_id,
             "skirmish_participant[1][warrior_id]": other_opposing_warrior.pk,
             "skirmish_participant[1][skirmish_action]": SkirmishActionChoices.SIMPLE_ATTACK,
         },
@@ -125,20 +139,20 @@ def test_skirmish_finish_round_view_takes_the_sides_from_the_roster_not_the_post
     that warrior into the player's line-up, where it attacked its own side; the rosters of the
     skirmish decide instead, so the round runs as a normal two-sided one.
     """
-    skirmish = SkirmishFactory(player_faction=current_savegame.player_faction)
-    player_warrior = WarriorFactory(faction=skirmish.player_faction)
-    opposing_warrior = WarriorFactory(faction=skirmish.non_player_faction)
-    skirmish.player_warriors.add(player_warrior)
-    skirmish.non_player_warriors.add(opposing_warrior)
+    skirmish = SkirmishFactory(attacking_faction=current_savegame.player_faction)
+    player_warrior = WarriorFactory(faction=skirmish.attacking_faction)
+    opposing_warrior = WarriorFactory(faction=skirmish.defending_faction)
+    skirmish.attacking_warriors.add(player_warrior)
+    skirmish.defending_warriors.add(opposing_warrior)
 
     response = logged_in_client.post(
         reverse("skirmish:skirmish-finish-round-view", kwargs={"pk": skirmish.pk}),
         data={
-            "skirmish_participant[0][faction_id]": skirmish.player_faction_id,
+            "skirmish_participant[0][faction_id]": skirmish.attacking_faction_id,
             "skirmish_participant[0][warrior_id]": player_warrior.pk,
             "skirmish_participant[0][skirmish_action]": SkirmishActionChoices.SIMPLE_ATTACK,
             # Lying about the side of the enemy warrior
-            "skirmish_participant[1][faction_id]": skirmish.player_faction_id,
+            "skirmish_participant[1][faction_id]": skirmish.attacking_faction_id,
             "skirmish_participant[1][warrior_id]": opposing_warrior.pk,
             "skirmish_participant[1][skirmish_action]": SkirmishActionChoices.SIMPLE_ATTACK,
         },
@@ -155,16 +169,16 @@ def test_skirmish_finish_round_view_rejects_a_warrior_outside_the_skirmish(logge
     The warrior ids arrive in the request body, so one naming somebody who is not fighting this
     skirmish is bad input rather than a server error.
     """
-    skirmish = SkirmishFactory(player_faction=current_savegame.player_faction)
-    player_warrior = WarriorFactory(faction=skirmish.player_faction)
-    skirmish.player_warriors.add(player_warrior)
+    skirmish = SkirmishFactory(attacking_faction=current_savegame.player_faction)
+    player_warrior = WarriorFactory(faction=skirmish.attacking_faction)
+    skirmish.attacking_warriors.add(player_warrior)
     uninvolved_faction = FactionFactory(savegame=current_savegame)
     uninvolved_warrior = WarriorFactory(faction=uninvolved_faction)
 
     response = logged_in_client.post(
         reverse("skirmish:skirmish-finish-round-view", kwargs={"pk": skirmish.pk}),
         data={
-            "skirmish_participant[0][faction_id]": skirmish.player_faction_id,
+            "skirmish_participant[0][faction_id]": skirmish.attacking_faction_id,
             "skirmish_participant[0][warrior_id]": player_warrior.pk,
             "skirmish_participant[0][skirmish_action]": SkirmishActionChoices.SIMPLE_ATTACK,
             "skirmish_participant[1][faction_id]": uninvolved_faction.pk,
@@ -180,14 +194,14 @@ def test_skirmish_finish_round_view_rejects_a_warrior_outside_the_skirmish(logge
 
 @pytest.mark.django_db
 def test_skirmish_finish_round_view_rejects_a_non_numeric_action(logged_in_client, current_savegame):
-    skirmish = SkirmishFactory(player_faction=current_savegame.player_faction)
-    player_warrior = WarriorFactory(faction=skirmish.player_faction)
-    skirmish.player_warriors.add(player_warrior)
+    skirmish = SkirmishFactory(attacking_faction=current_savegame.player_faction)
+    player_warrior = WarriorFactory(faction=skirmish.attacking_faction)
+    skirmish.attacking_warriors.add(player_warrior)
 
     response = logged_in_client.post(
         reverse("skirmish:skirmish-finish-round-view", kwargs={"pk": skirmish.pk}),
         data={
-            "skirmish_participant[0][faction_id]": skirmish.player_faction_id,
+            "skirmish_participant[0][faction_id]": skirmish.attacking_faction_id,
             "skirmish_participant[0][warrior_id]": player_warrior.pk,
             "skirmish_participant[0][skirmish_action]": "charge",
         },
@@ -204,9 +218,9 @@ def test_skirmish_finish_round_view_rejects_a_non_numeric_participant_index(logg
     The participant index is part of the field name, so it is request body too. Parsing happens
     before the view validates anything, so a hand-crafted index used to raise instead of answering.
     """
-    skirmish = SkirmishFactory(player_faction=current_savegame.player_faction)
-    player_warrior = WarriorFactory(faction=skirmish.player_faction)
-    skirmish.player_warriors.add(player_warrior)
+    skirmish = SkirmishFactory(attacking_faction=current_savegame.player_faction)
+    player_warrior = WarriorFactory(faction=skirmish.attacking_faction)
+    skirmish.attacking_warriors.add(player_warrior)
 
     response = logged_in_client.post(
         reverse("skirmish:skirmish-finish-round-view", kwargs={"pk": skirmish.pk}),
@@ -223,14 +237,14 @@ def test_skirmish_finish_round_view_rejects_a_non_numeric_participant_index(logg
 
 @pytest.mark.django_db
 def test_skirmish_finish_round_view_rejects_a_participant_without_a_warrior_id(logged_in_client, current_savegame):
-    skirmish = SkirmishFactory(player_faction=current_savegame.player_faction)
-    player_warrior = WarriorFactory(faction=skirmish.player_faction)
-    skirmish.player_warriors.add(player_warrior)
+    skirmish = SkirmishFactory(attacking_faction=current_savegame.player_faction)
+    player_warrior = WarriorFactory(faction=skirmish.attacking_faction)
+    skirmish.attacking_warriors.add(player_warrior)
 
     response = logged_in_client.post(
         reverse("skirmish:skirmish-finish-round-view", kwargs={"pk": skirmish.pk}),
         data={
-            "skirmish_participant[0][faction_id]": skirmish.player_faction_id,
+            "skirmish_participant[0][faction_id]": skirmish.attacking_faction_id,
             "skirmish_participant[0][skirmish_action]": SkirmishActionChoices.SIMPLE_ATTACK,
         },
     )
@@ -242,14 +256,14 @@ def test_skirmish_finish_round_view_rejects_a_participant_without_a_warrior_id(l
 
 @pytest.mark.django_db
 def test_skirmish_finish_round_view_refuses_a_one_sided_round(logged_in_client, current_savegame):
-    skirmish = SkirmishFactory(player_faction=current_savegame.player_faction)
-    player_warrior = WarriorFactory(faction=skirmish.player_faction)
-    skirmish.player_warriors.add(player_warrior)
+    skirmish = SkirmishFactory(attacking_faction=current_savegame.player_faction)
+    player_warrior = WarriorFactory(faction=skirmish.attacking_faction)
+    skirmish.attacking_warriors.add(player_warrior)
 
     response = logged_in_client.post(
         reverse("skirmish:skirmish-finish-round-view", kwargs={"pk": skirmish.pk}),
         data={
-            "skirmish_participant[0][faction_id]": skirmish.player_faction_id,
+            "skirmish_participant[0][faction_id]": skirmish.attacking_faction_id,
             "skirmish_participant[0][warrior_id]": player_warrior.pk,
             "skirmish_participant[0][skirmish_action]": SkirmishActionChoices.SIMPLE_ATTACK,
         },
@@ -262,7 +276,7 @@ def test_skirmish_finish_round_view_refuses_a_one_sided_round(logged_in_client, 
 
 @pytest.mark.django_db
 def test_skirmish_round_update_htmx_view_shows_the_skirmish(logged_in_client, current_savegame):
-    skirmish = SkirmishFactory(player_faction=current_savegame.player_faction)
+    skirmish = SkirmishFactory(attacking_faction=current_savegame.player_faction)
 
     response = logged_in_client.get(reverse("skirmish:skirmish-round-update-htmx", kwargs={"pk": skirmish.pk}))
 
@@ -281,7 +295,7 @@ def test_skirmish_round_update_htmx_view_cannot_show_a_skirmish_of_another_saveg
 
 @pytest.mark.django_db
 def test_skirmish_fight_button_update_htmx_view_shows_the_skirmish(logged_in_client, current_savegame):
-    skirmish = SkirmishFactory(player_faction=current_savegame.player_faction)
+    skirmish = SkirmishFactory(attacking_faction=current_savegame.player_faction)
 
     response = logged_in_client.get(reverse("skirmish:skirmish-fight-button-update-htmx", kwargs={"pk": skirmish.pk}))
 
@@ -304,7 +318,7 @@ def test_skirmish_fight_button_update_htmx_view_cannot_show_a_skirmish_of_anothe
 
 @pytest.mark.django_db
 def test_battle_history_update_htmx_view_lists_the_history_of_the_skirmish(logged_in_client, current_savegame):
-    skirmish = SkirmishFactory(player_faction=current_savegame.player_faction)
+    skirmish = SkirmishFactory(attacking_faction=current_savegame.player_faction)
     battle_history = BattleHistoryFactory(skirmish=skirmish)
 
     response = logged_in_client.get(reverse("skirmish:battle-history-update-htmx", kwargs={"skirmish_id": skirmish.id}))
@@ -327,17 +341,17 @@ def test_battle_history_update_htmx_view_hides_history_of_another_savegame(logge
 
 
 @pytest.mark.django_db
-def test_faction_warrior_list_update_htmx_view_lists_the_warriors_of_the_player_faction(
+def test_faction_warrior_list_update_htmx_view_lists_the_warriors_of_the_attacking_faction(
     logged_in_client, current_savegame
 ):
-    skirmish = SkirmishFactory(player_faction=current_savegame.player_faction)
-    player_warrior = WarriorFactory(faction=skirmish.player_faction)
-    skirmish.player_warriors.add(player_warrior)
+    skirmish = SkirmishFactory(attacking_faction=current_savegame.player_faction)
+    player_warrior = WarriorFactory(faction=skirmish.attacking_faction)
+    skirmish.attacking_warriors.add(player_warrior)
 
     response = logged_in_client.get(
         reverse(
             "skirmish:faction-warrior-list-update-htmx",
-            kwargs={"skirmish_id": skirmish.pk, "faction_id": skirmish.player_faction_id},
+            kwargs={"skirmish_id": skirmish.pk, "faction_id": skirmish.attacking_faction_id},
         )
     )
 
@@ -346,17 +360,17 @@ def test_faction_warrior_list_update_htmx_view_lists_the_warriors_of_the_player_
 
 
 @pytest.mark.django_db
-def test_faction_warrior_list_update_htmx_view_lists_the_warriors_of_the_non_player_faction(
+def test_faction_warrior_list_update_htmx_view_lists_the_warriors_of_the_defending_faction(
     logged_in_client, current_savegame
 ):
-    skirmish = SkirmishFactory(player_faction=current_savegame.player_faction)
-    opposing_warrior = WarriorFactory(faction=skirmish.non_player_faction)
-    skirmish.non_player_warriors.add(opposing_warrior)
+    skirmish = SkirmishFactory(attacking_faction=current_savegame.player_faction)
+    opposing_warrior = WarriorFactory(faction=skirmish.defending_faction)
+    skirmish.defending_warriors.add(opposing_warrior)
 
     response = logged_in_client.get(
         reverse(
             "skirmish:faction-warrior-list-update-htmx",
-            kwargs={"skirmish_id": skirmish.pk, "faction_id": skirmish.non_player_faction_id},
+            kwargs={"skirmish_id": skirmish.pk, "faction_id": skirmish.defending_faction_id},
         )
     )
 
@@ -365,17 +379,53 @@ def test_faction_warrior_list_update_htmx_view_lists_the_warriors_of_the_non_pla
 
 
 @pytest.mark.django_db
-def test_faction_warrior_list_update_htmx_view_cannot_list_warriors_of_another_savegame(
-    logged_in_client, current_savegame
-):
-    other_skirmish = SkirmishFactory()
-    other_warrior = WarriorFactory(faction=other_skirmish.player_faction)
-    other_skirmish.player_warriors.add(other_warrior)
+def test_faction_warrior_list_update_htmx_view_marks_the_players_own_roster(logged_in_client, current_savegame):
+    skirmish = SkirmishFactory(attacking_faction=current_savegame.player_faction)
 
     response = logged_in_client.get(
         reverse(
             "skirmish:faction-warrior-list-update-htmx",
-            kwargs={"skirmish_id": other_skirmish.pk, "faction_id": other_skirmish.player_faction_id},
+            kwargs={"skirmish_id": skirmish.pk, "faction_id": skirmish.attacking_faction_id},
+        )
+    )
+
+    assert response.status_code == 200
+    assert response.context["is_player"] is True
+
+
+@pytest.mark.django_db
+def test_faction_warrior_list_update_htmx_view_marks_a_rival_roster_as_not_the_players(
+    logged_in_client, current_savegame
+):
+    """
+    The flag decides whether these warrior cards let the human pick their action, so it has to follow
+    the savegame's player faction rather than the side of the skirmish the roster sits on.
+    """
+    skirmish = SkirmishFactory(attacking_faction=current_savegame.player_faction)
+
+    response = logged_in_client.get(
+        reverse(
+            "skirmish:faction-warrior-list-update-htmx",
+            kwargs={"skirmish_id": skirmish.pk, "faction_id": skirmish.defending_faction_id},
+        )
+    )
+
+    assert response.status_code == 200
+    assert response.context["is_player"] is False
+
+
+@pytest.mark.django_db
+def test_faction_warrior_list_update_htmx_view_cannot_list_warriors_of_another_savegame(
+    logged_in_client, current_savegame
+):
+    other_skirmish = SkirmishFactory()
+    other_warrior = WarriorFactory(faction=other_skirmish.attacking_faction)
+    other_skirmish.attacking_warriors.add(other_warrior)
+
+    response = logged_in_client.get(
+        reverse(
+            "skirmish:faction-warrior-list-update-htmx",
+            kwargs={"skirmish_id": other_skirmish.pk, "faction_id": other_skirmish.attacking_faction_id},
         )
     )
 

--- a/apps/skirmish/tests/test_views.py
+++ b/apps/skirmish/tests/test_views.py
@@ -39,7 +39,7 @@ def test_skirmish_fight_view_shows_the_skirmish(logged_in_client, current_savega
 
 
 @pytest.mark.django_db
-def test_skirmish_fight_view_marks_which_side_the_player_holds(logged_in_client, current_savegame):
+def test_skirmish_fight_view_marks_the_player_who_marched(logged_in_client, current_savegame):
     """
     The two flags drive whether a side's warrior cards offer the human a skirmish action, so exactly
     one of them may be True - here the player is the faction that marched.
@@ -50,6 +50,23 @@ def test_skirmish_fight_view_marks_which_side_the_player_holds(logged_in_client,
 
     assert response.context["attacker_is_player"] is True
     assert response.context["defender_is_player"] is False
+
+
+@pytest.mark.django_db
+def test_skirmish_fight_view_marks_the_player_who_was_marched_against(logged_in_client, current_savegame):
+    """
+    The player holds the defending side here, which is what makes the flags worth asserting: reading
+    them off side one would hand the human the rival's warband and let the AI command his own.
+    """
+    skirmish = SkirmishFactory(
+        attacking_faction=FactionFactory(savegame=current_savegame),
+        defending_faction=current_savegame.player_faction,
+    )
+
+    response = logged_in_client.get(reverse("skirmish:skirmish-fight-view", kwargs={"pk": skirmish.pk}))
+
+    assert response.context["attacker_is_player"] is False
+    assert response.context["defender_is_player"] is True
 
 
 @pytest.mark.django_db
@@ -380,12 +397,19 @@ def test_faction_warrior_list_update_htmx_view_lists_the_warriors_of_the_defendi
 
 @pytest.mark.django_db
 def test_faction_warrior_list_update_htmx_view_marks_the_players_own_roster(logged_in_client, current_savegame):
-    skirmish = SkirmishFactory(attacking_faction=current_savegame.player_faction)
+    """
+    The player holds the defending side, so the flag has to come from the savegame: taken from the
+    attacking side it would call the player's own warband the enemy and stop him commanding it.
+    """
+    skirmish = SkirmishFactory(
+        attacking_faction=FactionFactory(savegame=current_savegame),
+        defending_faction=current_savegame.player_faction,
+    )
 
     response = logged_in_client.get(
         reverse(
             "skirmish:faction-warrior-list-update-htmx",
-            kwargs={"skirmish_id": skirmish.pk, "faction_id": skirmish.attacking_faction_id},
+            kwargs={"skirmish_id": skirmish.pk, "faction_id": skirmish.defending_faction_id},
         )
     )
 
@@ -398,15 +422,18 @@ def test_faction_warrior_list_update_htmx_view_marks_a_rival_roster_as_not_the_p
     logged_in_client, current_savegame
 ):
     """
-    The flag decides whether these warrior cards let the human pick their action, so it has to follow
-    the savegame's player faction rather than the side of the skirmish the roster sits on.
+    The mirror image: the rival marched, and being the attacker must not make its warband the human's
+    to command.
     """
-    skirmish = SkirmishFactory(attacking_faction=current_savegame.player_faction)
+    skirmish = SkirmishFactory(
+        attacking_faction=FactionFactory(savegame=current_savegame),
+        defending_faction=current_savegame.player_faction,
+    )
 
     response = logged_in_client.get(
         reverse(
             "skirmish:faction-warrior-list-update-htmx",
-            kwargs={"skirmish_id": skirmish.pk, "faction_id": skirmish.defending_faction_id},
+            kwargs={"skirmish_id": skirmish.pk, "faction_id": skirmish.attacking_faction_id},
         )
     )
 

--- a/apps/skirmish/views.py
+++ b/apps/skirmish/views.py
@@ -31,15 +31,27 @@ class SkirmishFightView(SavegameScopedQuerysetMixin, generic.DetailView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
 
-        context["player_faction"] = self.object.player_faction
-        context["non_player_faction"] = self.object.non_player_faction
+        # The skirmish names its two sides by role, so whether a side is the player's - and therefore
+        # whether its warrior cards let the human pick an action instead of showing the AI's decision -
+        # is decided here, against the savegame. At most one of the two is True: a savegame that has no
+        # player faction yet makes both False rather than guessing at a side
+        current_savegame: Savegame = Savegame.objects.get_current_savegame(user_id=self.request.user.id)
+        player_faction_id = current_savegame.player_faction_id
+
+        context["attacking_faction"] = self.object.attacking_faction
+        context["defending_faction"] = self.object.defending_faction
+        context["attacker_is_player"] = self.object.attacking_faction_id == player_faction_id
+        context["defender_is_player"] = self.object.defending_faction_id == player_faction_id
         context["battle_log"] = self.object.battle_logs.all()
 
         return context
 
     def get(self, request, *args, **kwargs):
         skirmish = self.get_object()
-        current_savegame = skirmish.player_faction.savegame
+        # Straight from the savegame rather than from a side of the skirmish: the scoped queryset above
+        # already guarantees this skirmish belongs to the current savegame, and which of its sides is
+        # the player's is no longer the row's business
+        current_savegame: Savegame = Savegame.objects.get_current_savegame(user_id=request.user.id)
         if (
             self.model.objects.for_savegame(savegame_id=current_savegame.id)
             .has_started()
@@ -66,15 +78,15 @@ class SkirmishFinishRoundView(RunningSavegameRequiredMixin, SavegameScopedQuerys
         self.object = (
             self.get_queryset()
             .filter(id=self.kwargs.get("pk"))
-            .prefetch_related("player_warriors", "non_player_warriors")
+            .prefetch_related("attacking_warriors", "defending_warriors")
             .first()
         )
         if not self.object:
             return HttpResponse(status=HTTPStatus.NOT_FOUND)
         skirmish_participants = querydict_to_nested_dict(querydict=request.POST, prefix="skirmish_participant")
 
-        player_warrior_participants = []
-        opposing_warrior_participants = []
+        attacking_participants = []
+        defending_participants = []
 
         # Every value here arrives in the request body, so anything missing or non-numeric is bad
         # input rather than a server error. The posted "faction_id" is deliberately not read: see
@@ -88,20 +100,20 @@ class SkirmishFinishRoundView(RunningSavegameRequiredMixin, SavegameScopedQuerys
             return HttpResponse(status=HTTPStatus.BAD_REQUEST)
 
         # Which side a warrior fights on comes from this skirmish's own rosters. Not from the posted
-        # "faction_id", which is client-supplied - naming the opposing faction there put an enemy
-        # warrior into the player's line-up, attacking its own side. And not from "warrior.faction"
+        # "faction_id", which is client-supplied - naming the opposing faction there put a warrior into
+        # the other side's line-up, attacking his own side. And not from "warrior.faction"
         # either, which is what the template fills that field with: it changes the moment a captive
         # is recruited, so it disagrees with the roster the warrior actually fights in.
         # Both relations are prefetched above, so this costs no extra queries, and keying by id
         # means a warrior listed twice cannot produce a duplicate-row lookup error.
-        player_roster = {warrior.id: warrior for warrior in self.object.player_warriors.all()}
-        opposing_roster = {warrior.id: warrior for warrior in self.object.non_player_warriors.all()}
+        attacking_roster = {warrior.id: warrior for warrior in self.object.attacking_warriors.all()}
+        defending_roster = {warrior.id: warrior for warrior in self.object.defending_warriors.all()}
 
         for warrior_id, skirmish_action in participants:
-            if warrior_id in player_roster:
-                warrior, side = player_roster[warrior_id], player_warrior_participants
-            elif warrior_id in opposing_roster:
-                warrior, side = opposing_roster[warrior_id], opposing_warrior_participants
+            if warrior_id in attacking_roster:
+                warrior, side = attacking_roster[warrior_id], attacking_participants
+            elif warrior_id in defending_roster:
+                warrior, side = defending_roster[warrior_id], defending_participants
             else:
                 # A warrior id naming someone who is not fighting this skirmish
                 return HttpResponse(status=HTTPStatus.BAD_REQUEST)
@@ -109,15 +121,15 @@ class SkirmishFinishRoundView(RunningSavegameRequiredMixin, SavegameScopedQuerys
             side.append(SkirmishParticipant(warrior=warrior, skirmish_action=skirmish_action))
 
         # Ensure that all lists contain warriors
-        if len(player_warrior_participants) == 0 or len(opposing_warrior_participants) == 0:
+        if len(attacking_participants) == 0 or len(defending_participants) == 0:
             return HttpResponse(status=HTTPStatus.BAD_REQUEST)
 
         # Start duel
         handle_message(
             StartDuel(
                 skirmish=self.object,
-                skirmish_participants_1=player_warrior_participants,
-                skirmish_participants_2=opposing_warrior_participants,
+                skirmish_participants_1=attacking_participants,
+                skirmish_participants_2=defending_participants,
             )
         )
 
@@ -168,22 +180,24 @@ class FactionWarriorListUpdateHtmxView(generic.TemplateView):
     def get_context_data(self, **kwargs):
         # Both ids arrive in the URL: the skirmish has to belong to the current savegame, and the
         # faction has to be one of the two fighting it - otherwise an unrelated faction would fall
-        # through to the non-player branch below and be shown those warriors
+        # through to the defending branch below and be shown those warriors
         current_savegame: Savegame = Savegame.objects.get_current_savegame(user_id=self.request.user.id)
         skirmish = get_object_or_404(
             Skirmish.objects.for_savegame(savegame_id=current_savegame.id if current_savegame else None),
             pk=self.kwargs.get("skirmish_id"),
         )
         faction = get_object_or_404(
-            Faction.objects.filter(id__in=(skirmish.player_faction_id, skirmish.non_player_faction_id)),
+            Faction.objects.filter(id__in=(skirmish.attacking_faction_id, skirmish.defending_faction_id)),
             pk=self.kwargs.get("faction_id"),
         )
 
         context = super().get_context_data(**kwargs)
-        if faction == skirmish.player_faction:
-            context["object_list"] = skirmish.player_warriors.all()
+        if faction.pk == skirmish.attacking_faction_id:
+            context["object_list"] = skirmish.attacking_warriors.all()
         else:
-            context["object_list"] = skirmish.non_player_warriors.all()
-        context["is_player"] = skirmish.player_faction == faction
+            context["object_list"] = skirmish.defending_warriors.all()
+        # Which roster to show is the skirmish's business, but whether the human commands it is the
+        # savegame's: being the attacker no longer means being the player
+        context["is_player"] = faction.pk == current_savegame.player_faction_id
 
         return context

--- a/apps/skirmish/views.py
+++ b/apps/skirmish/views.py
@@ -27,6 +27,8 @@ class SkirmishListView(SavegameScopedQuerysetMixin, generic.ListView):
 class SkirmishFightView(SavegameScopedQuerysetMixin, generic.DetailView):
     model = Skirmish
     template_name = "skirmish/skirmish_fight.html"
+    object = None
+    current_savegame = None
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
@@ -34,9 +36,9 @@ class SkirmishFightView(SavegameScopedQuerysetMixin, generic.DetailView):
         # The skirmish names its two sides by role, so whether a side is the player's - and therefore
         # whether its warrior cards let the human pick an action instead of showing the AI's decision -
         # is decided here, against the savegame. At most one of the two is True: a savegame that has no
-        # player faction yet makes both False rather than guessing at a side
-        current_savegame: Savegame = Savegame.objects.get_current_savegame(user_id=self.request.user.id)
-        player_faction_id = current_savegame.player_faction_id
+        # player faction yet makes both False rather than guessing at a side. Both the savegame and the
+        # skirmish were resolved by get() below, which is the only caller
+        player_faction_id = self.current_savegame.player_faction_id
 
         context["attacking_faction"] = self.object.attacking_faction
         context["defending_faction"] = self.object.defending_faction
@@ -47,21 +49,26 @@ class SkirmishFightView(SavegameScopedQuerysetMixin, generic.DetailView):
         return context
 
     def get(self, request, *args, **kwargs):
-        skirmish = self.get_object()
-        # Straight from the savegame rather than from a side of the skirmish: the scoped queryset above
+        # Both are resolved once here and kept on the view. Handing off to super().get() instead would
+        # fetch the same skirmish a second time - and its own scoped get_queryset() re-reads the
+        # savegame to do it - so the two lines it saves cost three queries per render.
+        # Straight from the savegame rather than from a side of the skirmish: the scoped queryset
         # already guarantees this skirmish belongs to the current savegame, and which of its sides is
         # the player's is no longer the row's business
-        current_savegame: Savegame = Savegame.objects.get_current_savegame(user_id=request.user.id)
+        self.object = self.get_object()
+        self.current_savegame: Savegame = Savegame.objects.get_current_savegame(user_id=request.user.id)
+
         if (
-            self.model.objects.for_savegame(savegame_id=current_savegame.id)
+            self.model.objects.for_savegame(savegame_id=self.current_savegame.id)
             .has_started()
             .unresolved()
-            .exclude(id=skirmish.id)
+            .exclude(id=self.object.id)
             .exists()
         ):
             messages.add_message(request, messages.WARNING, "Please finish your other skirmishes first.")
             return HttpResponseRedirect(reverse("skirmish:skirmish-list-view"))
-        return super().get(request, *args, **kwargs)
+
+        return self.render_to_response(self.get_context_data(object=self.object))
 
 
 class SkirmishFinishRoundView(RunningSavegameRequiredMixin, SavegameScopedQuerysetMixin, generic.DetailView):


### PR DESCRIPTION
## What the story asked for

> Remove, this is technical dept. A skirmish has two sides, the savegame determines which one (if any) is the player.

`Skirmish` carried the player in its own schema — `player_faction`/`non_player_faction` and
`player_warriors`/`non_player_warriors` — even though side one is simply whoever *marched*. Both creation
paths already put the initiator there, and `BaseSkirmishGenerator` already called its own guards "the
attacking side" and "the defending side". The model even carried a `TODO` proposing this rename.

Closes #21

## What this builds

**The two sides are named for their role.** `attacking_faction`/`defending_faction`,
`attacking_warriors`/`defending_warriors`, related names `attacking_skirmishes`/`defending_skirmishes`, and a
`RenameField` migration (`skirmish.0005`). `Savegame.player_faction` is untouched — that is the one place the
player legitimately lives.

**Three sites genuinely needed a player, and now ask the savegame for one:**

| Site | Before | After |
|---|---|---|
| `handle_win_open_skirmishes_when_the_game_ends` | gave a won game to side one | compares both sides against `savegame.player_faction_id` |
| `SkirmishFightView` | template hard-coded `is_player=True` for the left box | `attacker_is_player` / `defender_is_player` off the savegame |
| `FactionWarriorListUpdateHtmxView` | `is_player = skirmish.player_faction == faction` | `is_player = faction.pk == current_savegame.player_faction_id` |

That flag decides whether a warrior card lets the human choose an action or shows the AI's decision, so
getting it from the row rather than the savegame is what would hand a player the rival's warband.

The event handler stays free of queries as [strict mode](docs/patterns/strict-mode.md) requires:
`player_faction_id` is a column on the savegame already in hand, and the command handler raising
`SavegameEnded` already `select_related`s both faction sides.

Behaviour is unchanged for every skirmish that exists today, because the player is always the attacker. What
changes is that the schema no longer forbids anything else.

## One more assumption of the same kind (third commit)

`RemoveQuestContractAsActiveQuest` carried a `faction` of its own, which the emitting event handler filled
with the skirmish's **attacking side**. That is only ever the signatory because the faction which accepts a
quest is also the one that marches — and `handle_faction_wins_skirmish` decides the loot from
`quest_contract.faction_id` instead, so the two handlers already disagreed about who owns a contract.
Clearing the active quest of a faction that never signed is a silent no-op, so the holder would have kept a
finished quest forever the moment the two came apart.

The command no longer carries a faction at all — the contract records who signed it, and the command handler
reads it there, where a query is allowed. Removing the field is the fix: it is what made disagreement
possible.

This bug was **latent, not live**: today's only contract-bearing skirmishes are quest skirmishes, where the
signatory is the attacker. It becomes reachable as soon as anything else holds a contract.

## CI

`pre-commit run --all-files` and `uv run pytest --cov` both green, every round.
**528 tests, 100% branch coverage** (the gate's `fail_under` is untouched, no `# pragma: no cover` added).

## Review coverage

Sharded review over `git diff main...HEAD` at `18ab6f1` (1024 changed lines → 3 shards), completed in 651s of
a 720s budget. No retries, no partial shards. The third commit got a separate delta check.

| Lens | Result |
|---|---|
| Correctness and message-bus wiring | complete — 0 findings |
| Data layer, savegame scoping, migrations | complete — 0 findings |
| Test honesty and coverage substance | complete — **2 findings, both fixed** |
| Spec conformance and simplification | **not reviewed** — dropped by the shard-count rule for this diff size |

**Both findings were in my own new tests and both were real:** they could not tell the new savegame-derived
flags from the old hard-coded ones, because every fixture put the player on the attacking side — the one case
both implementations get right. Three of the four cases now put the player on the *defending* side, and I
verified they fail against the reverted logic and pass against the real code. The quest-contract test was
checked the same way, against a non-signatory faction.

The skipped lens is the lowest-ranked one; its risk here is low, since the diff is a rename plus three
localised reads and the correctness lens independently confirmed the untouched files carry no logic change.

## Verified in a browser

Beyond the suite, the migration and the UI were checked against a real populated database (17 existing
skirmishes) with a scenario holding both cases:

- Migration `0005` applied to the populated dev database; FK values, M2M rosters, victors and rounds all
  survived. A review shard independently rebuilt the old schema and confirmed the same, including that
  Django's `RenameField` renames the auto-created M2M through table and repoints both its FK columns.
- Skirmish list shows **Attacker** / **Defender**, and a skirmish whose *attacker is a rival* is still
  listed — so scoping through `attacking_faction__savegame_id` is not a hole.
- Player marching: player warriors get all four actions, the rival gets one fixed.
- **Player defending** (the case no flow produces yet): the rival attacker gets the fixed action and the
  player's own warriors get the full dropdown. The old code would have inverted exactly this.
- A full round fought from the defending side: the chosen *Defensive stance* landed on a player warrior,
  pairings crossed sides correctly, round advanced. No 5xx, no tracebacks, no console errors.
- Another savegame's skirmish 404s, and a faction not in the skirmish 404s rather than falling through to
  the defending branch.

Scenario data and the review user were removed afterwards; the dev database is back to its previous counts.

The fight page was re-checked after the fourth commit changed how it renders — both warriors, both faction
names, two selects and exactly one four-option dropdown, i.e. nothing silently dropped out of the context.

## Two loose ends, tidied (fourth commit)

Both were listed here as follow-ups and then asked for.

**`SkirmishFightView` resolved its skirmish twice.** `get()` fetched the row, then handed off to
`super().get()`, which fetched the same row again — and its scoped `get_queryset()` re-read the savegame to do
it. The object and the savegame are now resolved once, kept on the view, and the response rendered in `get()`.
**Three fewer queries per render** — the duplicate row fetch, the savegame re-read its scoped queryset needed,
and the savegame read `get_context_data()` no longer repeats. Measured before and after by swapping the
pre-commit file back in; the absolute total depends on how much the skirmish holds, so the delta is the
meaningful figure (31 → 28 in one scenario, 21 → 18 in a leaner one, three either way). The two remaining
`skirmish_skirmish` queries are the row fetch and the `exists()` guard, which are different queries rather
than a leftover duplicate.

Worth noting for the reviewer: because this project's convention forbids asserting on rendered HTML, a context
key vanishing here would have produced a blank warrior list that the suite could not see. That is why the
render was checked explicitly rather than trusted to the green suite.

**`.claude/worktrees/` is now gitignored**, next to the already-ignored `.claude/runs/`. A registered git
worktree is still untracked content, so without it a nested checkout of the project can be committed by
accident.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
