### PR TITLE
Three UI oddities found while driving the app

### DIFF
--- a/apps/common/templates/base.html
+++ b/apps/common/templates/base.html
@@ -110,12 +110,17 @@
         event.detail.headers['X-CSRFToken'] = '{{ csrf_token }}';
     });
     // Notifications
+    // UIkit's own default. A second is not long enough to read a sentence like "This game is over.
+    // Start a new savegame to play on.", and for several actions the toast is the only feedback there
+    // is. Named once so the three call sites below cannot drift apart again.
+    const NOTIFICATION_TIMEOUT = 5000;
+
     document.body.addEventListener("notification", function (e) {
         UIkit.notification({
             message: e.detail.value,
             status: 'success',
             pos: 'top-center',
-            timeout: 1000,
+            timeout: NOTIFICATION_TIMEOUT,
         });
     });
     document.body.addEventListener('htmx:beforeOnLoad', function (evt) {
@@ -124,7 +129,7 @@
                 message: "An error has occurred.",
                 status: 'danger',
                 pos: 'bottom-center',
-                timeout: 1000,
+                timeout: NOTIFICATION_TIMEOUT,
             });
         }
     });
@@ -134,7 +139,7 @@
             message: "{{ message|safe }}",
             status: "{{ message.level_tag }}",
             pos: 'top-center',
-            timeout: 1000,
+            timeout: NOTIFICATION_TIMEOUT,
         });
     {% endfor %}
 </script>

--- a/apps/faction/templates/faction/faction_detail.html
+++ b/apps/faction/templates/faction/faction_detail.html
@@ -5,7 +5,7 @@
 
     <div class="uk-child-width-expand@s uk-text-center uk-grid-medium" uk-grid>
         <div>
-            <h2>My faction</h2>
+            <h2>{% if is_player_faction %}My faction{% else %}Rival faction{% endif %}</h2>
             <div class="uk-card uk-card-default uk-card-body uk-margin-bottom">
                 <h3>Details</h3>
                 <table class="uk-table">
@@ -39,7 +39,10 @@
                     <p class="uk-text-meta">Your warriors have already fought this month.</p>
                 {% endif %}
             </div>
-            {% include 'faction/warrior/components/fyrd_card.html' with faction=object %}
+            {# Only your own fyrd can be drafted from, so on a rival's page the card is a button that could only fail #}
+            {% if is_player_faction %}
+                {% include 'faction/warrior/components/fyrd_card.html' with faction=object %}
+            {% endif %}
         </div>
         <div>
             {% include "faction/warrior/components/warrior_list.html" with faction=object warrior_list=warrior_list %}

--- a/apps/faction/templates/faction/faction_detail.html
+++ b/apps/faction/templates/faction/faction_detail.html
@@ -1,11 +1,10 @@
 {% extends 'base.html' %}
 
 {% block content %}
-    <h1>Faction "{{ object }}"</h1>
+    <h1>{% if is_player_faction %}My faction{% else %}Rival faction{% endif %} "{{ object }}"</h1>
 
     <div class="uk-child-width-expand@s uk-text-center uk-grid-medium" uk-grid>
         <div>
-            <h2>{% if is_player_faction %}My faction{% else %}Rival faction{% endif %}</h2>
             <div class="uk-card uk-card-default uk-card-body uk-margin-bottom">
                 <h3>Details</h3>
                 <table class="uk-table">

--- a/apps/faction/tests/test_views.py
+++ b/apps/faction/tests/test_views.py
@@ -32,14 +32,12 @@ def player_faction_ready_to_march(current_savegame) -> Faction:
 @pytest.mark.django_db
 def test_faction_detail_view_shows_the_faction(logged_in_client, current_savegame):
     faction = current_savegame.player_faction
-    # The template links to the leader unconditionally, so a faction without one cannot be rendered
-    faction.leader = WarriorFactory(faction=faction)
-    faction.save()
+    warrior = WarriorFactory(faction=faction)
 
     response = logged_in_client.get(reverse("faction:faction-detail-view", kwargs={"pk": faction.id}))
 
     assert response.status_code == 200
-    assert list(response.context["warrior_list"]) == [faction.leader]
+    assert list(response.context["warrior_list"]) == [warrior]
 
 
 @pytest.mark.django_db

--- a/apps/faction/tests/test_views.py
+++ b/apps/faction/tests/test_views.py
@@ -53,6 +53,30 @@ def test_faction_detail_view_hides_factions_of_other_savegames(logged_in_client,
 
 
 @pytest.mark.django_db
+def test_faction_detail_view_marks_the_players_own_faction(logged_in_client, current_savegame):
+    response = logged_in_client.get(
+        reverse("faction:faction-detail-view", kwargs={"pk": current_savegame.player_faction.id})
+    )
+
+    assert response.status_code == 200
+    assert response.context["is_player_faction"] is True
+
+
+@pytest.mark.django_db
+def test_faction_detail_view_does_not_mark_a_rival_as_the_players_own(logged_in_client, current_savegame):
+    """
+    The same template serves both, and on a rival's page "My faction" and the fyrd card offer a draft
+    the scoping on DraftWarriorFromFyrdView can only refuse.
+    """
+    rival_faction = FactionFactory(savegame=current_savegame)
+
+    response = logged_in_client.get(reverse("faction:faction-detail-view", kwargs={"pk": rival_faction.id}))
+
+    assert response.status_code == 200
+    assert response.context["is_player_faction"] is False
+
+
+@pytest.mark.django_db
 def test_faction_detail_view_offers_an_attack_on_a_rival(
     logged_in_client, current_savegame, player_faction_ready_to_march
 ):

--- a/apps/faction/views.py
+++ b/apps/faction/views.py
@@ -32,6 +32,12 @@ class FactionDetailView(SavegameScopedQuerysetMixin, generic.DetailView):
         # Asked through the same queryset the attack view resolves its target with, so the button
         # and the page it leads to can never disagree about who may be attacked
         current_savegame: Savegame = Savegame.objects.get_current_savegame(user_id=self.request.user.id)
+        # This template serves the player's own faction and a rival's alike, so it has to know which
+        # it is looking at: "My faction" over a rival's details is simply wrong, and the fyrd card
+        # offers a draft the scoping on DraftWarriorFromFyrdView can only refuse.
+        # A savegame without a player faction gives None here, which no faction id equals - so it
+        # renders as a rival's page, which is right: there is no own faction yet.
+        context["is_player_faction"] = self.object.id == current_savegame.player_faction_id
         context["can_be_attacked"] = (
             Faction.objects.attackable_by(
                 player_faction=current_savegame.player_faction, month=current_savegame.current_month

--- a/apps/skirmish/handlers/commands/warrior.py
+++ b/apps/skirmish/handlers/commands/warrior.py
@@ -121,6 +121,17 @@ def handle_warrior_losing_morale(*, context: warrior.ReduceMorale) -> list[Event
 
     context.warrior = Warrior.objects.reduce_morale(obj=context.warrior, lost_morale=context.lost_morale)
 
+    # The loss comes first, because the battle log is written in the order the events arrive and a
+    # warrior who flees before losing the morale that made him flee reads backwards
+    if context.lost_morale > 0:
+        message_list.append(
+            WarriorLostMorale(
+                skirmish=context.skirmish,
+                warrior=context.warrior,
+                lost_morale=context.lost_morale,
+            )
+        )
+
     if context.warrior.current_morale <= 0:
         context.warrior = Warrior.objects.set_condition(
             obj=context.warrior, condition=Warrior.ConditionChoices.CONDITION_FLEEING
@@ -130,15 +141,6 @@ def handle_warrior_losing_morale(*, context: warrior.ReduceMorale) -> list[Event
             WarriorHasFled(
                 skirmish=context.skirmish,
                 warrior=context.warrior,
-            )
-        )
-
-    if context.lost_morale > 0:
-        message_list.append(
-            WarriorLostMorale(
-                skirmish=context.skirmish,
-                warrior=context.warrior,
-                lost_morale=context.lost_morale,
             )
         )
 

--- a/apps/skirmish/tests/handlers/commands/test_warrior.py
+++ b/apps/skirmish/tests/handlers/commands/test_warrior.py
@@ -148,9 +148,10 @@ def test_handle_warrior_losing_morale_makes_the_warrior_flee_without_morale_left
 
     result = handle_warrior_losing_morale(context=ReduceMorale(skirmish=skirmish, warrior=warrior, lost_morale=5))
 
+    # The loss before the rout: the battle log is written in the order the events arrive
     assert result == [
-        WarriorHasFled(skirmish=skirmish, warrior=warrior),
         WarriorLostMorale(skirmish=skirmish, warrior=warrior, lost_morale=5),
+        WarriorHasFled(skirmish=skirmish, warrior=warrior),
     ]
     warrior.refresh_from_db()
     assert warrior.condition == Warrior.ConditionChoices.CONDITION_FLEEING


### PR DESCRIPTION
Three unrelated UI oddities found while driving the app in a browser. One commit each.

Closes #37

### 1. The battle log reported a rout backwards

The log is written in the order the events arrive, and `handle_warrior_losing_morale` raised
`WarriorHasFled` before `WarriorLostMorale` — so a fight read *"is out of morale and fled the field"*
and then *"lost 2 morale"*, the loss arriving after the thing it caused.

Not a bare swap of two `append` calls: the flee branch also flips the warrior's condition and rebinds
`context.warrior`, so the two blocks change places whole. `WarriorLostMorale` now carries the instance
from before the flip, which no consumer can tell apart — the only handler registered for it logs
`str(warrior)` and never reads `condition`. queuebie's runner is strict FIFO, so the two log lines
simply change places and nothing else moves.

### 2. Toasts vanished after one second

One second is not long enough to read a sentence like *"This game is over. Start a new savegame to play
on."*, and for several actions the toast is the only feedback there is. `timeout: 1000` appeared at
three call sites in `base.html`; all three now use one `NOTIFICATION_TIMEOUT = 5000` — UIkit's own
default — so they cannot drift apart again.

### 3. A rival's faction page offered actions belonging to your own

`faction_detail.html` serves the player's faction and a rival's alike, so a rival's page carried the
heading **"My faction"** and a fyrd card whose **"Draft warrior"** button `DraftWarriorFromFyrdView`'s
`PlayerFactionScopedQuerysetMixin` could only refuse. The guard was never the problem — a control
offered where it can only fail was.

`FactionDetailView` now puts `is_player_faction` in the context; the heading reads *"Rival faction"* and
the fyrd card is gone on a rival's page. A savegame with no player faction yet gives `None`, which no
faction id equals, so it renders as a rival's page — correct, there is no own faction to draft into.
The existing "Attack this faction" button keeps its `can_be_attacked` guard, already the right way
round.

### 4. Two things the review turned up on the way past

Not in the issue, fixed on request rather than in passing:

- The page named the faction in an `<h1>` and again in the column `<h2>` below it. The `<h1>` takes over
  the my/rival distinction, so one heading states both facts instead of two heading levels each stating
  half. The two cards in that column keep their own headings.
- A comment in `test_faction_detail_view_shows_the_faction` claimed the template links the leader
  unconditionally. That stopped being true when the `{% if object.leader %}` guard went in, and the test
  at the bottom of the same module now asserts the opposite. The test only ever needed a warrior to read
  back, so it makes one rather than a leader.

### Not in scope

`DraftWarriorFromFyrdView`'s scoping itself. The issue confirms the guard holds and #29 already tests
it; this only stops offering the control.

Two more the browser pass found, both pre-existing and neither fixed here:

1. **A rival's page offers a "Sell" button on the rival's unused items.** The same defect as issue item
   3, one column to the right, and a write rather than a card. Not a leak — `ItemSellView` carries
   `PlayerFactionScopedQuerysetMixin` and refuses exactly as the draft view does. Confirmed by reading
   `item_sell_card.html` and the view, not by clicking: the smoke rival had every item worn.
2. **A rival's page addresses the player in the second person about the rival's property** — "Every item
   you own is being worn.", "You hold no captives." Fixing the `<h1>` made these *more* conspicuous, not
   less: the page now says "Rival faction" at the top and "every item you own" two columns over.

### CI

Both gates green on `4a9fe16`: `pre-commit run --all-files` passes, and `uv run pytest --cov` is
**524 passed, 100% branch coverage**.

### Review coverage

- **Lens 01 (correctness and message-bus wiring)** — complete, **no findings**. It traced every consumer
  of the two reordered events and confirmed queuebie's FIFO ordering, and checked that
  `is_player_faction` cannot raise or be wrong for any savegame state the view is reachable in.
- **Lens 01 ran at reduced scope.** Its first attempt stalled having written nothing; the single
  permitted retry was narrowed to `apps/skirmish/handlers/commands/warrior.py`, `apps/faction/views.py`
  and `apps/faction/templates/faction/faction_detail.html`. **Three changed files therefore had no
  reviewer:** the two test modules and `apps/common/templates/base.html`.
- **Lenses 02 (data layer), 03 (tests) and 04 (conformance) were not run** — by design: the shard table
  allocates one shard to a 71-line diff.
- **The review round ran against `85973c1`, so commit 4 above post-dates it** and had no reviewer either.
  A template heading move and a test tidy, both behind the green gates.

### Content review — played in a browser

All three fixes confirmed working against a throwaway savegame at `4a9fe16`.

- **Battle log** — with a warrior seeded to 1 morale holding a defensive stance, round 5 produced:
  `Ian lost 1 morale.` / `Ian is out of morale and fled the field.` / `Gary lost 1 morale.` The loss
  above the rout, the comrades' drop below it. Only the morale value was seeded; the ordering is what
  the handler produced.
- **Toast** — measured in the page rather than eyeballed: appears immediately, leaves after **5854 ms**
  (5000 ms plus UIkit's fade). Confirmed on both paths — the htmx `notification` after a draft, and the
  finish-month refusal.
- **Rival page** — `Rival faction "East Gracemouth"`, no fyrd card, no draft button; `Attack this
  faction` still offered. Own page still reads `My faction "Mercia"` and drafts successfully
  (`POST …/draft/fyrd => 200`).
- Baseline sweep clean: every nav page 200, no tracebacks, 0 console errors, no 5xx in the server log.
  One gap — the *completion* path of Finish month was not reached inside the interaction budget (the
  refusal path was verified end to end). The month flow is untouched by this diff.

**Two pre-existing problems the browser pass turned up, both left unfixed** (see the out-of-scope list
below).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
