### PR TITLE
Prune the backlog & link code TODOs to their issues

### DIFF
--- a/apps/config/settings.py
+++ b/apps/config/settings.py
@@ -191,7 +191,6 @@ AXES_SENSITIVE_PARAMETERS = ["username", "ip_address"]
 # Pointing it at BASE_DIR would include everything in ".venv/", which uv creates inside the project,
 # so a dependency shipping a "handlers/commands/" directory would register handlers on our bus.
 QUEUEBIE_APP_BASE_PATH = BASE_DIR / "apps"
-# TODO: Fix handlers so we can enable this
 QUEUEBIE_STRICT_MODE = True
 
 

--- a/apps/faction/messages/events/warrior.py
+++ b/apps/faction/messages/events/warrior.py
@@ -14,7 +14,7 @@ class RequestWarriorForPub(Event):
     # TODO: this is a command and not an event by name -> maybe just use commands? seems legit
     savegame: Savegame
     faction: Faction | None
-    # TODO: faction reicht nicht aus, ich möchte ja auch für andere factions des savegames warriors im pool haben
+    # TODO (#47): faction reicht nicht aus, ich möchte ja auch für andere factions des savegames warriors im pool haben
     culture: Culture
     generator_class: type[BaseWarriorGenerator]
     month: int

--- a/apps/finance/managers/transaction.py
+++ b/apps/finance/managers/transaction.py
@@ -20,7 +20,6 @@ class TransactionQuerySet(models.QuerySet):
 
 class TransactionManager(manager.Manager):
     def create_transaction(self, *, reason: str, amount: int, faction: Faction, month: int):
-        # TODO: call this only in a command, not directly
         return self.create(reason=reason, amount=amount, faction=faction, month=month)
 
     def current_balance(self, *, faction_id: int) -> int:

--- a/apps/item/services/generators/item/base.py
+++ b/apps/item/services/generators/item/base.py
@@ -50,7 +50,6 @@ class BaseItemGenerator:
         if not item_type:
             raise RuntimeError("No item type found.")
 
-        # TODO: sometimes "item_type" is None
         dice_notation = DiceNotation(dice_string=item_type.base_value, modifier=modifier)
         price = abs(dice_notation.expectancy_value * dice_notation.sides * max(modifier, 1))
 

--- a/apps/savegame/models/savegame.py
+++ b/apps/savegame/models/savegame.py
@@ -5,7 +5,7 @@ from apps.faction.models import Faction
 from apps.savegame.managers.savegame import SavegameManager
 
 
-# TODO: can't remove a savegame via the admin due to FK issues
+# TODO (#41): can't remove a savegame via the admin due to FK issues
 class Savegame(models.Model):
     class OutcomeChoices(models.IntegerChoices):
         OUTCOME_RUNNING = 1, "Running"

--- a/apps/skirmish/models/warrior.py
+++ b/apps/skirmish/models/warrior.py
@@ -10,7 +10,7 @@ from apps.skirmish.services.skirmish.skirmish_action_decision import SkirmishAct
 
 
 # TODO: move to warrior app?
-# TODO: permanent injuries would be nice -> each has a modificator and reduces a value like HP or dex
+# TODO (#53): permanent injuries would be nice -> each has a modificator and reduces a value like HP or dex
 #  -> ankle -> reduce dex, missing finger -> strength etc.
 class Warrior(models.Model):
     NO_WEAPON_ATTACK = "1d3"
@@ -87,7 +87,7 @@ class Warrior(models.Model):
     def __str__(self) -> str:
         return self.name
 
-    # TODO: add property when a certain value is really high to add a nickname like "Victor the Fast"
+    # TODO (#42): add property when a certain value is really high to add a nickname like "Victor the Fast"
     #  (good and bad cases)
 
     @property
@@ -115,8 +115,8 @@ class Warrior(models.Model):
         return int(self.recruitment_price / 2)
 
     def get_skirmish_actions(self) -> list[tuple]:
-        # TODO: show only the ones the warrior has depending on his level
-        # TODO: use XP to add more skirmish actions -> every level gets a fixed action to keep it simple
+        # TODO (#52): show only the ones the warrior has depending on his level
+        # TODO (#52): use XP to add more skirmish actions -> every level gets a fixed action to keep it simple
         return SkirmishActionChoices.choices
 
     def decide_skirmish_action(self) -> [int, str]:

--- a/apps/town/models/town.py
+++ b/apps/town/models/town.py
@@ -10,21 +10,18 @@ class Town(models.Model):
         HALL_MEDIUM = 2, "Great Hall"
         HALL_LARGE = 3, "High Hall"
 
-    # TODO: upgrading works, but the levels grant nothing yet
     class WeaponsmithChoices(models.IntegerChoices):
         WEAPONSMITH_NONE = 0, "No weaponsmith"
         WEAPONSMITH_SMALL = 1, "Smithy"
         WEAPONSMITH_MEDIUM = 2, "Forge Hall"
         WEAPONSMITH_LARGE = 3, "Master Forge"
 
-    # TODO: upgrading works, but the levels grant nothing yet
     class MarketChoices(models.IntegerChoices):
         MARKET_NONE = 0, "No marketplace"
         MARKET_SMALL = 1, "Marketplace"
         MARKET_MEDIUM = 2, "Trading Post"
         MARKET_LARGE = 3, "High Market"
 
-    # TODO: upgrading works, but the levels grant nothing yet
     class SanctuaryChoices(models.IntegerChoices):
         SANCTUARY_NONE = 0, "No sanctuary"
         SANCTUARY_SMALL = 1, "Shrine"

--- a/apps/warrior/handlers/commands/warrior.py
+++ b/apps/warrior/handlers/commands/warrior.py
@@ -26,7 +26,7 @@ from apps.warrior.services.generators.warrior.leader import LeaderWarriorGenerat
 
 @message_registry.register_command(command=ReplenishWarriorMorale)
 def handle_replenish_warrior_morale(*, context: ReplenishWarriorMorale) -> list[Event] | Event | None:
-    # TODO: when money goes below X, let warriors morale drop once they don't get payed
+    # TODO (#45): when money goes below X, let warriors morale drop once they don't get payed
 
     # Morale is always filled up to the max
     recovered_morale = context.warrior.max_morale - context.warrior.current_morale

--- a/apps/warrior/services/generators/warrior/base.py
+++ b/apps/warrior/services/generators/warrior/base.py
@@ -16,7 +16,7 @@ class BaseWarriorGenerator:
     HEALTH_SIGMA: int
     MORALE_MU: int
     MORALE_SIGMA: int
-    # TODO: ensure that both stats are never zero
+    # TODO (#41): ensure that both stats are never zero
     STATS_MU: int
     STATS_SIGMA: int
     STATS_MIN: int

--- a/docs/collaboration/backlog.md
+++ b/docs/collaboration/backlog.md
@@ -2,24 +2,13 @@
 
 Open ideas and unfinished work, kept in German as written.
 
+A line leaves this file the moment it becomes an issue — the issue is the record, and an idea kept in
+both places drifts. See [writing an issue](writing-issues.md) for what promoting a line involves.
+
 ## MVP
-
-### Dashboard / Generelles
-
-* Gefangen müssen sich auch heilen am Wochenende
-* Events, die Einfluss auf Krieger oder sonstiges haben (Max HP ändert etc.)
-    * Event-Klasse, die man wie die Notifications registriert und die eine Wahrscheinlichkeit und einen Trigger haben,
-      wenn beides passt, wird es ausgeführt. So kann man super fix neue Events dazu bauen
-
-### Faction
-
-* Umgang mit "pleite" sein
-* Items kaufen und verkaufen (per Command im View)
 
 ### Warrior
 
-* Level & Erfahrungspunkte haben noch keinen Einfluss
-* Nicknames, je nachdem wie die Attribute ausfallen (Collum the Weak, Charles the Quick)
 * Training:
     * Wie mache ich das? Trainiert man Dinge, die dann Bonus auf Fähigkeiten geben?
     * Pro Skill (Stärke, Dex, HP, Moral) ein Fortschrittsbalken?
@@ -27,20 +16,6 @@ Open ideas and unfinished work, kept in German as written.
     * Oder kann man damit nur XP sammeln?
     * Was ist, wenn ich das Training allgemein und nicht pro Krieger definiere? Und jeder,
       der nicht kämpft und gesund ist, das gleiche macht.
-
-### Training
-
-* Trainingsart auswählen und im Savegame hinterlegen
-* In der Woche Progress für alle Teilnehmer hinterlegen inkl. Punkt-Updates
-
-### Skirmish
-
-* Passive/defensiv-stärkende Attack-Action?
-* Fliehen als Aktion
-* Gegner-KI für Kampfaktionen
-* Kampfaktion soll an Item hängen, Warrior bekommt eine Funktion, die entscheidet, was es im Select zu sehen gibt
-* Morph swap htmx Fabi damit Formulare sich nicht ändern → gewählte Action springt immer zurück
-* Permanente Verletzungen
 
 ### Technisches
 
@@ -52,8 +27,6 @@ Open ideas and unfinished work, kept in German as written.
 
 ## Offene Punkte aus den Building-Effekten
 
-* Rivalen bauen nie — jeder Gebäude-Effekt ist reine Spieler-Progression, siehe
-  [town buildings](../patterns/town-buildings.md)
 * Marktplatz und Sanctuary haben je nur einen Effekt, der Weaponsmith-Bonus ist die einzige Quelle für
   besseres Gear
 * Item-Preise (~30–150 Silber) liegen eine Größenordnung unter den Baukosten, dadurch ist die


### PR DESCRIPTION
Docs and comments only — no behaviour changes. 530 tests pass, pre-commit clean.

## The backlog stops duplicating the issue tracker

`docs/collaboration/backlog.md` went from 63 lines to 33. A line leaves the file the moment it becomes an
issue, which is now stated at the top with a pointer to
[writing an issue](docs/collaboration/writing-issues.md) — an idea kept in both places drifts, and this
one had.

Removed because they are **already implemented**, each verified against the code rather than assumed:

| Backlog line | Where it actually lives |
|---|---|
| Passive/defensiv-stärkende Attack-Action | `SkirmishActionChoices.DEFENSIVE_STANCE`, tuned by #34 |
| Gegner-KI für Kampfaktionen | `SkirmishActionDecisionService` |
| In der Woche Progress für alle Teilnehmer | `handle_progress_warrior_training` |
| Trainingsart auswählen | `TrainingEditView` + `TrainingForm`, reachable from the training list |
| Items kaufen und verkaufen (per Command im View) | the views dispatch commands already |

Removed because an issue owns them now: #4, #10, #42, #45, #46, and #50–#54 for the rest.

What stays is what is genuinely still open and not worth a ticket: the training design questions, event
queue logging, the ECS note, and the three building-balance observations.

## Code TODOs point at their issues

Six deleted as stale, each checked first:

- `settings.py` — "Fix handlers so we can enable this" above `QUEUEBIE_STRICT_MODE = True`. Strict mode
  is on.
- `town/models/town.py` ×3 — "upgrading works, but the levels grant nothing yet". All three buildings
  own a documented lever, see [town buildings](docs/patterns/town-buildings.md).
- `finance/managers/transaction.py` — "call this only in a command". Its only caller is
  `handle_create_transaction`, which is a command handler.
- `item/services/generators/item/base.py` — "sometimes item_type is None". A `raise RuntimeError` guard
  sits directly above it.

Seven now carry the issue that owns them: `(#41)`, `(#42)`, `(#45)`, `(#47)`, `(#52)`, `(#53)`.

The rest are code-organisation notes ("move to model?", "this is ugly") and stay as they are — the code
is the right place for a note about the code.

## Two new papercuts on #41

Both found by this audit, neither fixed here:

- A savegame cannot be deleted in the admin — `Savegame` ↔ `Faction.player_faction` is a cascade cycle.
- The zero-stat guard cannot fire: `STATS_MIN` is 1/3/4, so `max(gauss(...), STATS_MIN)` never returns
  zero and the `while` loop never runs twice. Checked the siblings rather than generalising —
  `max_health`, `max_morale` and the four `*_progress` rolls floor at `0` and *can* re-roll, so only the
  two stat loops are redundant.

## #54 was verified in a browser and corrected

Driven against a fresh smoke savegame. The reported symptom — the chosen combat action springing back
after a round — **does not reproduce**: the choice is posted before anything re-renders.

The mechanism underneath is real (`morph:innerHTML` discards a pending select, which the template's own
TODO already says), but `updateFactionWarriorList` has one emitter and it fires *after* the post, so a
pending choice and a refresh never coexist. #54 is retitled and rewritten with the evidence, and may
belong on #41 or be closed outright.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
