### PR TITLE
The player's month log shows rival factions' bookkeeping

### DIFF
--- a/apps/month/handlers/commands/month.py
+++ b/apps/month/handlers/commands/month.py
@@ -44,7 +44,14 @@ def handle_prepare_month(*, context: PrepareMonth) -> list[Event]:
 
 
 @message_registry.register_command(command=CreatePlayerMonthLog)
-def handle_create_player_month_log(*, context: CreatePlayerMonthLog) -> Event:
+def handle_create_player_month_log(*, context: CreatePlayerMonthLog) -> Event | None:
+    # Every faction of the savegame gets its month, so the recovery handlers emit this command for
+    # the rivals too - and their lines would drown the player's own in his log. The producers cannot
+    # tell them apart: they are event handlers, where strict mode's database blocker forbids the
+    # traversal below. This command handler may query, and every producer passes through it.
+    if context.faction.savegame.player_faction_id != context.faction.id:
+        return None
+
     player_month_log = PlayerMonthLog.objects.create_record(
         title=context.title,
         month=context.month,
@@ -56,6 +63,9 @@ def handle_create_player_month_log(*, context: CreatePlayerMonthLog) -> Event:
 
 @message_registry.register_command(command=ClearPlayerMonthLog)
 def handle_clear_player_month_log(*, context: ClearPlayerMonthLog) -> Event:
+    # Wider than the player faction on purpose, even though handle_create_player_month_log no longer
+    # writes anything else: this is what sweeps up the rival rows a savegame accumulated before that
+    # guard existed
     PlayerMonthLog.objects.for_savegame(savegame_id=context.savegame.id).filter(
         month__lt=context.current_month
     ).delete()

--- a/apps/month/managers/player_month_log.py
+++ b/apps/month/managers/player_month_log.py
@@ -6,6 +6,11 @@ class PlayerMonthLogQuerySet(models.QuerySet):
     def for_savegame(self, *, savegame_id: int):
         return self.filter(faction__savegame=savegame_id)
 
+    def for_player_faction(self, *, faction_id: int):
+        # The log the player reads is his own faction's, not his savegame's - scoping to the
+        # savegame would let the id from the URL reach a rival's rows
+        return self.filter(faction_id=faction_id)
+
 
 class PlayerMonthLogManager(manager.Manager):
     def create_record(self, *, title: str, month: int, faction_id: int):

--- a/apps/month/tests/handlers/commands/test_month.py
+++ b/apps/month/tests/handlers/commands/test_month.py
@@ -1,9 +1,10 @@
 import pytest
 
 from apps.faction.tests.factories.faction import FactionFactory
-from apps.month.handlers.commands.month import handle_prepare_month
-from apps.month.messages.commands.month import PrepareMonth
-from apps.month.messages.events.month import FactionMonthPrepared
+from apps.month.handlers.commands.month import handle_create_player_month_log, handle_prepare_month
+from apps.month.messages.commands.month import CreatePlayerMonthLog, PrepareMonth
+from apps.month.messages.events.month import FactionMonthPrepared, PlayerMonthLogCreated
+from apps.month.models.player_month_log import PlayerMonthLog
 from apps.savegame.tests.factories.savegame import SavegameFactory
 from apps.training.tests.factories.training import TrainingFactory
 
@@ -102,3 +103,57 @@ def test_handle_prepare_month_without_a_player_faction():
 
     assert result[0].training is None
     assert result[0].current_month == 5
+
+
+@pytest.mark.django_db
+def test_handle_create_player_month_log_writes_the_line():
+    savegame = SavegameFactory()
+    savegame.player_faction = FactionFactory(savegame=savegame)
+    savegame.save()
+
+    result = handle_create_player_month_log(
+        context=CreatePlayerMonthLog(
+            title="The fyrd has grown by 1 new recruitee!", month=3, faction=savegame.player_faction
+        )
+    )
+
+    player_month_log = PlayerMonthLog.objects.get()
+    assert result == PlayerMonthLogCreated(player_month_log=player_month_log)
+    assert player_month_log.title == "The fyrd has grown by 1 new recruitee!"
+
+
+@pytest.mark.django_db
+def test_handle_create_player_month_log_drops_the_line_of_a_rival_faction():
+    """
+    Recovery is faction-wide on purpose, so a rival's warriors produce these commands too. The
+    choke point every producer passes through is the only place that can tell them apart - the
+    producers are event handlers, where the traversal this does is blocked.
+    """
+    savegame = SavegameFactory()
+    savegame.player_faction = FactionFactory(savegame=savegame)
+    savegame.save()
+    rival_faction = FactionFactory(savegame=savegame)
+
+    result = handle_create_player_month_log(
+        context=CreatePlayerMonthLog(title="Warrior RivalMan healed 2 HP.", month=3, faction=rival_faction)
+    )
+
+    assert result is None
+    assert PlayerMonthLog.objects.exists() is False
+
+
+@pytest.mark.django_db
+def test_handle_create_player_month_log_without_a_player_faction():
+    """
+    Reachable before the player's faction exists: the savegame row is created first. Nobody to log
+    for, so nothing is written rather than a row nobody can ever read.
+    """
+    savegame = SavegameFactory(player_faction=None)
+    faction = FactionFactory(savegame=savegame)
+
+    result = handle_create_player_month_log(
+        context=CreatePlayerMonthLog(title="Buildings earned 50 silver this month.", month=3, faction=faction)
+    )
+
+    assert result is None
+    assert PlayerMonthLog.objects.exists() is False

--- a/apps/month/tests/managers/test_player_month_log.py
+++ b/apps/month/tests/managers/test_player_month_log.py
@@ -1,0 +1,20 @@
+import pytest
+
+from apps.month.models.player_month_log import PlayerMonthLog
+from apps.month.tests.factories.player_month_log import PlayerMonthLogFactory
+from apps.savegame.tests.factories.savegame import SavegameFactory
+
+
+@pytest.mark.django_db
+def test_for_player_faction_excludes_the_logs_of_rival_factions():
+    """
+    A savegame holds the player's faction plus its rivals, so scoping by savegame would still let
+    the id from the URL reach a rival's log line.
+    """
+    savegame = SavegameFactory()
+    player_month_log = PlayerMonthLogFactory(faction__savegame=savegame)
+    PlayerMonthLogFactory(faction__savegame=savegame)
+
+    result = PlayerMonthLog.objects.for_player_faction(faction_id=player_month_log.faction_id)
+
+    assert list(result) == [player_month_log]

--- a/apps/month/tests/test_views.py
+++ b/apps/month/tests/test_views.py
@@ -62,6 +62,28 @@ def test_finish_month_view_lets_a_rival_faction_recover(logged_in_client, curren
 
 
 @pytest.mark.django_db
+def test_finish_month_view_logs_the_recovery_of_the_player_faction_only(logged_in_client, current_savegame):
+    """
+    Flow test rather than a unit test: that the rivals get a month at all only exists in the
+    registry, and the producers of these log lines are two handlers away from the one guarding them.
+
+    Both warriors heal - recovery is faction-wide on purpose - but only one of them is bookkeeping
+    the player has any business reading. Rival lines used to outnumber his own, a savegame starting
+    with three to five of them.
+    """
+    TrainingFactory(faction=current_savegame.player_faction)
+    WarriorFactory(faction=current_savegame.player_faction, current_health=16, max_health=20)
+    rival_faction = FactionFactory(savegame=current_savegame)
+    WarriorFactory(faction=rival_faction, current_health=18, max_health=20)
+
+    response = logged_in_client.post(reverse("month:finish-month-view"))
+
+    assert response.status_code == 200
+    assert PlayerMonthLog.objects.filter(faction=current_savegame.player_faction).exists() is True
+    assert PlayerMonthLog.objects.filter(faction=rival_faction).exists() is False
+
+
+@pytest.mark.django_db
 def test_finish_month_view_refuses_a_finished_savegame(logged_in_client, current_savegame):
     """
     Covers the htmx branch of RunningSavegameRequiredMixin; which views carry it at all is asserted
@@ -118,6 +140,20 @@ def test_player_month_log_list_view_hides_logs_of_another_savegame(logged_in_cli
 
 
 @pytest.mark.django_db
+def test_player_month_log_list_view_hides_logs_of_a_rival_faction(logged_in_client, current_savegame):
+    """
+    Scoping to the savegame is not enough here: the rivals of the player live in it too, and the log
+    is his own faction's bookkeeping rather than his savegame's.
+    """
+    PlayerMonthLogFactory(faction=FactionFactory(savegame=current_savegame))
+
+    response = logged_in_client.get(reverse("month:player-month-log-list-view"))
+
+    assert response.status_code == 200
+    assert list(response.context["playermonthlog_list"]) == []
+
+
+@pytest.mark.django_db
 def test_acknowledge_player_month_log_view_removes_the_log(logged_in_client, current_savegame):
     player_month_log = PlayerMonthLogFactory(faction=current_savegame.player_faction)
 
@@ -142,6 +178,20 @@ def test_acknowledge_player_month_log_view_cannot_remove_a_log_of_another_savega
 
     assert response.status_code == 404
     assert PlayerMonthLog.objects.filter(pk=foreign_log.pk).exists() is True
+
+
+@pytest.mark.django_db
+def test_acknowledge_player_month_log_view_cannot_remove_a_log_of_a_rival_faction(logged_in_client, current_savegame):
+    """
+    The stricter mixin is what closes this one: a rival of the player's own savegame passes the
+    savegame scoping, and the id from the URL was enough to acknowledge its row away.
+    """
+    rival_log = PlayerMonthLogFactory(faction=FactionFactory(savegame=current_savegame))
+
+    response = logged_in_client.delete(reverse("month:player-month-log-remove-view", kwargs={"pk": rival_log.pk}))
+
+    assert response.status_code == 404
+    assert PlayerMonthLog.objects.filter(pk=rival_log.pk).exists() is True
 
 
 @pytest.mark.django_db

--- a/apps/month/views.py
+++ b/apps/month/views.py
@@ -9,7 +9,7 @@ from queuebie.runner import handle_message
 
 from apps.month.messages.commands.month import PrepareMonth
 from apps.month.models.player_month_log import PlayerMonthLog
-from apps.savegame.mixins import RunningSavegameRequiredMixin, SavegameScopedQuerysetMixin
+from apps.savegame.mixins import PlayerFactionScopedQuerysetMixin, RunningSavegameRequiredMixin
 from apps.savegame.models.savegame import Savegame
 from apps.skirmish.models import Skirmish
 
@@ -44,12 +44,12 @@ class FinishMonthView(RunningSavegameRequiredMixin, generic.View):
         return response
 
 
-class PlayerMonthLogListView(SavegameScopedQuerysetMixin, generic.ListView):
+class PlayerMonthLogListView(PlayerFactionScopedQuerysetMixin, generic.ListView):
     model = PlayerMonthLog
     template_name = "player-month-log/components/player_month_log_list.html"
 
 
-class AcknowledgePlayerMonthLogView(SavegameScopedQuerysetMixin, SingleObjectMixin, generic.View):
+class AcknowledgePlayerMonthLogView(PlayerFactionScopedQuerysetMixin, SingleObjectMixin, generic.View):
     """
     Not a DeleteView: since Django 4.0 that one deletes in form_valid() on POST, so for this
     htmx-driven DELETE none of its form machinery runs. Inheriting it only meant that


### PR DESCRIPTION
## What the story asked for

The player's month log was showing the rivals' bookkeeping. Recovery is faction-wide on purpose, so
every faction's warriors heal and recover morale each month — but the two handlers that log it wrote
`CreatePlayerMonthLog(faction=context.warrior.faction)` unconditionally, and the queryset behind the
player's view filtered on `faction__savegame`. With three to five rivals per savegame, the player's own
lines were the minority in his own log.

Closes #49

## What I built

**The write is guarded at the one place that can.** `handle_create_player_month_log` returns `None`
when the command's faction is not the savegame's player faction. The producers are event handlers,
where strict mode's database blocker forbids the relation traversal; this is a command handler, where
the query is allowed, and every producer passes through it — including the ones #3 and #48 are about to
add. Both the bail-out shape and the expression itself follow existing precedent
(`handle_restock_pub_mercenaries`, `handle_replenish_fyrd_reserve`).

**The read is scoped as well**, because it answers a different question. `PlayerMonthLogQuerySet` gains
`for_player_faction()`, and `PlayerMonthLogListView` and `AcknowledgePlayerMonthLogView` move from
`SavegameScopedQuerysetMixin` to `PlayerFactionScopedQuerysetMixin`. Without this the id from the URL
still reached a rival's row.

**`ClearPlayerMonthLog` was re-read, not rewritten.** Deleting by savegame is correct and deliberately
wider than the player faction: it is what sweeps the rival rows an existing savegame accumulated before
the guard existed. A comment now says so.

Tests: three unit tests on the guard (player writes, rival dropped, savegame with no player faction
yet), a manager test for `for_player_faction`, a same-savegame-rival scoping test for each of the two
views, and the flow test the issue specified — `PrepareMonth` through `FinishMonthView` with a player
faction and a rival both holding wounded warriors, asserting rows for the player and none for the
rival. Confirmed it fails on the unguarded code, producing exactly the rival line from the issue.

## CI

Both gates green on the first round: `pre-commit run --all-files` and `uv run pytest --cov` behind the
100% branch gate. No fixes were needed after review, so this is the same commit the review and the
browser saw.

## Review coverage

Three of four lenses ran to completion, none with a finding at confidence 80 or above: correctness and
message-bus wiring, data layer and savegame scoping, and test honesty. **Lens 04, spec conformance and
simplification, was not reviewed** — the 154-line diff gets one shard by the size rule, and lenses are
taken in rank order. Lens 02 was launched beyond that budget on purpose, since this story's subject is
scoping and the generic ranking would have dropped exactly the lens that matters most here.

Two candidates were raised and refuted, both worth knowing about: the guard's extra query per
`CreatePlayerMonthLog` on the recovery path (the identical idiom is pre-existing at
`apps/faction/handlers/commands/warrior.py:25`, and `player_faction_id` lives on `Savegame`, so there
is no cheaper path), and `ClearPlayerMonthLog` staying on `for_savegame` (correct, and the sweeping is
its job).

## Content review

Walked in a real browser on a throwaway database: log in, create a savegame, every nav entry, finish a
month, and the month-log list and acknowledge controls. Eleven steps, all passing, no findings.

The decisive one: a month finished with all six factions holding wounded warriors. The log came back
with four lines, every one of them the player's own — his salaries, his building income, and his
warrior Jeremy healing and recovering morale. Nothing for the five rivals' warriors, where `main`
would have shown ten such lines. Every rival still healed and refilled morale, so the guard silences
the log without stopping the recovery. Acknowledging the player's own line returned 202; a rival row
seeded by hand returned 404 on delete and never appeared in the list. No 5xx anywhere in the server
log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
