### PR TITLE
A captive never heals, however long you hold him

### DIFF
--- a/apps/faction/handlers/commands/faction.py
+++ b/apps/faction/handlers/commands/faction.py
@@ -1,6 +1,6 @@
 import random
 
-from django.db.models import F
+from django.db.models import F, Q
 from faker import Faker
 from queuebie import message_registry
 from queuebie.messages import Command, Event
@@ -171,6 +171,11 @@ def handle_replenish_fyrd_reserve(*, context: ReplenishFyrdReserve) -> Event | N
 
 @message_registry.register_command(command=DetermineWarriorsWithReducedMorale)
 def handle_determine_warriors_with_reduced_morale(*, context: DetermineWarriorsWithReducedMorale) -> Event:
+    # The roster only, captives deliberately excluded - unlike the healing sweep below, which does
+    # reach them. Health is what a captor can mend; spirit is not, and
+    # "handle_replenish_warrior_morale" refills to the maximum unconditionally, so a month in an
+    # enemy cell would restore a man completely.
+    #
     # Only warriors below their maximum have anything to recover - replenishing the rest would be
     # a no-op further down the chain
     warrior_qs = context.faction.warriors.exclude(condition=Warrior.ConditionChoices.CONDITION_DEAD).filter(
@@ -186,9 +191,25 @@ def handle_determine_warriors_with_reduced_morale(*, context: DetermineWarriorsW
 
 @message_registry.register_command(command=DetermineInjuredWarriors)
 def handle_determine_injured_warriors(*, context: DetermineInjuredWarriors) -> list[Command]:
-    # Get all injured but not dead warriors of "faction"
-    warrior_qs = context.faction.warriors.exclude(condition=Warrior.ConditionChoices.CONDITION_DEAD).filter(
-        current_health__lt=F("max_health")
+    """
+    Every injured man this faction is responsible for: its own roster, plus the captives it holds.
+
+    A captive is on nobody's roster - capture clears "warrior.faction" - so without the second half
+    he heals nothing for as long as he is held, and a prisoner taken unconscious stays at the health
+    the blow that felled him left him at for ever.
+
+    Healing him from his captor's sweep reaches him exactly once: a warrior belongs to exactly one
+    captor, and this runs once per faction per month. The captor rides along on the command because
+    it is his sanctuary that does the mending and his month log the line belongs in - the healing
+    handler cannot read either off a warrior whose own faction is None.
+
+    Matched by id rather than through the reverse accessor of "captured_warriors", which would join
+    per captor row and hand the same man out twice were he ever held by two of them.
+    """
+    warrior_qs = (
+        Warrior.objects.filter(Q(faction=context.faction) | Q(id__in=context.faction.captured_warriors.all()))
+        .exclude(condition=Warrior.ConditionChoices.CONDITION_DEAD)
+        .filter(current_health__lt=F("max_health"))
     )
 
     event_list = []
@@ -196,6 +217,7 @@ def handle_determine_injured_warriors(*, context: DetermineInjuredWarriors) -> l
         event_list.append(
             # TODO: this should be an event, not a command
             HealInjuredWarrior(
+                faction=context.faction,
                 warrior=warrior,
                 month=context.month,
             )

--- a/apps/faction/templates/faction/warrior/components/captured_warrior_list.html
+++ b/apps/faction/templates/faction/warrior/components/captured_warrior_list.html
@@ -1,7 +1,6 @@
 <div hx-get="{% url 'faction:faction-captured-warrior-list-htmx' faction.id %}"
      hx-trigger="loadFactionCapturedWarriorList from:body">
     <h2>Captured warriors</h2>
-    {# todo: captured warriors never heal HP #}
     {% for warrior in faction.captured_warriors.all %}
         {% include 'warrior/components/warrior_card.html' with warrior=warrior faction=faction is_captured=True %}
     {% empty %}

--- a/apps/faction/tests/handlers/commands/test_faction.py
+++ b/apps/faction/tests/handlers/commands/test_faction.py
@@ -265,7 +265,7 @@ def test_handle_determine_injured_warriors_with_injured_warrior():
         context=DetermineInjuredWarriors(faction=injured_warrior.faction, month=3)
     )
 
-    assert result == [HealInjuredWarrior(warrior=injured_warrior, month=3)]
+    assert result == [HealInjuredWarrior(faction=injured_warrior.faction, warrior=injured_warrior, month=3)]
 
 
 @pytest.mark.django_db
@@ -284,6 +284,82 @@ def test_handle_determine_injured_warriors_ignores_dead_warriors():
     dead_warrior = WarriorFactory(current_health=0, max_health=20, condition=Warrior.ConditionChoices.CONDITION_DEAD)
 
     result = handle_determine_injured_warriors(context=DetermineInjuredWarriors(faction=dead_warrior.faction, month=3))
+
+    assert result == []
+
+
+@pytest.mark.django_db
+def test_handle_determine_injured_warriors_selects_a_captive_of_this_faction():
+    """
+    A captive is on nobody's roster, so his captor's sweep is the only one that can reach him.
+    """
+    captor = FactionFactory()
+    captive = WarriorFactory(
+        faction=None,
+        savegame=captor.savegame,
+        culture=captor.culture,
+        current_health=0,
+        max_health=20,
+        condition=Warrior.ConditionChoices.CONDITION_UNCONSCIOUS,
+    )
+    captor.captured_warriors.add(captive)
+
+    result = handle_determine_injured_warriors(context=DetermineInjuredWarriors(faction=captor, month=3))
+
+    # The captor rides along, because the mending is done at his sanctuary and logged in his month
+    assert result == [HealInjuredWarrior(faction=captor, warrior=captive, month=3)]
+
+
+@pytest.mark.django_db
+def test_handle_determine_injured_warriors_leaves_another_factions_captive_alone():
+    captor = FactionFactory()
+    captive = WarriorFactory(
+        faction=None,
+        savegame=captor.savegame,
+        culture=captor.culture,
+        current_health=0,
+        max_health=20,
+        condition=Warrior.ConditionChoices.CONDITION_UNCONSCIOUS,
+    )
+    captor.captured_warriors.add(captive)
+    bystander_faction = FactionFactory(savegame=captor.savegame)
+
+    result = handle_determine_injured_warriors(context=DetermineInjuredWarriors(faction=bystander_faction, month=3))
+
+    assert result == []
+
+
+@pytest.mark.django_db
+def test_handle_determine_injured_warriors_skips_a_captive_at_full_health():
+    captor = FactionFactory()
+    healed_captive = WarriorFactory(
+        faction=None, savegame=captor.savegame, culture=captor.culture, current_health=20, max_health=20
+    )
+    captor.captured_warriors.add(healed_captive)
+
+    result = handle_determine_injured_warriors(context=DetermineInjuredWarriors(faction=captor, month=3))
+
+    assert result == []
+
+
+@pytest.mark.django_db
+def test_handle_determine_injured_warriors_skips_a_dead_captive():
+    """
+    Only the unconscious are ever taken prisoner, but a captive can be killed off the field by
+    anything that reaches him, and no sanctuary mends a corpse.
+    """
+    captor = FactionFactory()
+    dead_captive = WarriorFactory(
+        faction=None,
+        savegame=captor.savegame,
+        culture=captor.culture,
+        current_health=0,
+        max_health=20,
+        condition=Warrior.ConditionChoices.CONDITION_DEAD,
+    )
+    captor.captured_warriors.add(dead_captive)
+
+    result = handle_determine_injured_warriors(context=DetermineInjuredWarriors(faction=captor, month=3))
 
     assert result == []
 
@@ -318,6 +394,26 @@ def test_handle_determine_warriors_with_reduced_morale_skips_dead_warriors():
     )
 
     assert result == FactionWarriorsWithReducedMoraleDetermined(faction=faction, warrior_list=[], month=3)
+
+
+@pytest.mark.django_db
+def test_handle_determine_warriors_with_reduced_morale_passes_over_captives():
+    """
+    Health is what a captor mends, spirit is not - unlike the healing sweep, this one stays on the
+    roster on purpose. Morale is refilled to the maximum further down the chain, and a month in an
+    enemy cell restoring a man completely reads wrong.
+    """
+    captor = FactionFactory()
+    captive = WarriorFactory(
+        faction=None, savegame=captor.savegame, culture=captor.culture, current_morale=5, max_morale=20
+    )
+    captor.captured_warriors.add(captive)
+
+    result = handle_determine_warriors_with_reduced_morale(
+        context=DetermineWarriorsWithReducedMorale(faction=captor, month=3)
+    )
+
+    assert result == FactionWarriorsWithReducedMoraleDetermined(faction=captor, warrior_list=[], month=3)
 
 
 @pytest.mark.django_db

--- a/apps/warrior/handlers/commands/warrior.py
+++ b/apps/warrior/handlers/commands/warrior.py
@@ -47,8 +47,10 @@ def handle_replenish_warrior_morale(*, context: ReplenishWarriorMorale) -> list[
 
 @message_registry.register_command(command=HealInjuredWarrior)
 def handle_heal_injured_warrior(*, context: HealInjuredWarrior) -> Event | None:
-    # How far the town's sanctuary can mend a warrior in one month
-    sanctuary = Sanctuary.get_building_by_type(building_type=context.warrior.faction.town.sanctuary)
+    # How far the town's sanctuary can mend a warrior in one month. The faction is taken off the
+    # command rather than off the warrior, because a captive has none: capture clears
+    # "warrior.faction", and he is mended in his captor's town, at his captor's sanctuary.
+    sanctuary = Sanctuary.get_building_by_type(building_type=context.faction.town.sanctuary)
     max_recoverable_health_points = sanctuary.MAX_HEALING_POINTS
 
     # Cap healed points at the maximum. randrange() excludes its upper bound, so it needs the "+ 1"
@@ -66,7 +68,7 @@ def handle_heal_injured_warrior(*, context: HealInjuredWarrior) -> Event | None:
 
     return WarriorHealthHealed(
         warrior=context.warrior,
-        faction=context.warrior.faction,
+        faction=context.faction,
         healed_points=healed_hp,
         month=context.month,
     )

--- a/apps/warrior/messages/commands/warrior.py
+++ b/apps/warrior/messages/commands/warrior.py
@@ -32,6 +32,9 @@ class ReplenishWarriorMorale(Command):
 
 @dataclass(kw_only=True)
 class HealInjuredWarrior(Command):
+    # The faction mending him, which is not always the one he belongs to: a captive is healed by the
+    # faction holding him, and capture has cleared his own
+    faction: Faction
     warrior: Warrior
     month: int
 

--- a/apps/warrior/tests/handlers/commands/test_warrior.py
+++ b/apps/warrior/tests/handlers/commands/test_warrior.py
@@ -2,16 +2,11 @@ from unittest import mock
 
 import pytest
 
-from apps.faction.messages.events.warrior import WarriorRecruited
 from apps.faction.tests.factories.faction import FactionFactory
 from apps.skirmish.models.warrior import Warrior
 from apps.skirmish.tests.factories.warrior import WarriorFactory
-from apps.warrior.handlers.commands.warrior import (
-    handle_heal_injured_warrior,
-    handle_recruit_captured_warrior,
-    handle_replenish_warrior_morale,
-)
-from apps.warrior.messages.commands.warrior import HealInjuredWarrior, RecruitCapturedWarrior, ReplenishWarriorMorale
+from apps.warrior.handlers.commands.warrior import handle_heal_injured_warrior, handle_replenish_warrior_morale
+from apps.warrior.messages.commands.warrior import HealInjuredWarrior, ReplenishWarriorMorale
 from apps.warrior.messages.events.warrior import WarriorHealthHealed, WarriorMoraleReplenished
 
 
@@ -156,22 +151,3 @@ def test_handle_heal_injured_warrior_wakes_a_captive_without_freeing_him():
     captive.refresh_from_db()
     assert captive.condition == Warrior.ConditionChoices.CONDITION_HEALTHY
     assert list(captor.captured_warriors.all()) == [captive]
-
-
-@pytest.mark.django_db
-def test_handle_recruit_captured_warrior_keeps_the_health_he_was_mended_to():
-    """
-    Recruiting is the moment a captive rejoins a roster, not a second course of treatment: the
-    months in the cell already brought him back, and taking him on adds nothing to that.
-    """
-    captor = FactionFactory()
-    captive = WarriorFactory(
-        faction=None, savegame=captor.savegame, culture=captor.culture, current_health=20, max_health=20
-    )
-    captor.captured_warriors.add(captive)
-
-    result = handle_recruit_captured_warrior(context=RecruitCapturedWarrior(warrior=captive, faction=captor, month=3))
-
-    assert result == WarriorRecruited(warrior=captive, faction=captor, recruitment_price=0, month=3)
-    captive.refresh_from_db()
-    assert captive.current_health == 20

--- a/apps/warrior/tests/handlers/commands/test_warrior.py
+++ b/apps/warrior/tests/handlers/commands/test_warrior.py
@@ -2,9 +2,16 @@ from unittest import mock
 
 import pytest
 
+from apps.faction.messages.events.warrior import WarriorRecruited
+from apps.faction.tests.factories.faction import FactionFactory
+from apps.skirmish.models.warrior import Warrior
 from apps.skirmish.tests.factories.warrior import WarriorFactory
-from apps.warrior.handlers.commands.warrior import handle_heal_injured_warrior, handle_replenish_warrior_morale
-from apps.warrior.messages.commands.warrior import HealInjuredWarrior, ReplenishWarriorMorale
+from apps.warrior.handlers.commands.warrior import (
+    handle_heal_injured_warrior,
+    handle_recruit_captured_warrior,
+    handle_replenish_warrior_morale,
+)
+from apps.warrior.messages.commands.warrior import HealInjuredWarrior, RecruitCapturedWarrior, ReplenishWarriorMorale
 from apps.warrior.messages.events.warrior import WarriorHealthHealed, WarriorMoraleReplenished
 
 
@@ -33,7 +40,9 @@ def test_handle_heal_injured_warrior_heals_rolled_amount():
     warrior = WarriorFactory(current_health=5, max_health=20)
 
     with mock.patch("apps.warrior.handlers.commands.warrior.random.randrange", return_value=5):
-        result = handle_heal_injured_warrior(context=HealInjuredWarrior(warrior=warrior, month=3))
+        result = handle_heal_injured_warrior(
+            context=HealInjuredWarrior(faction=warrior.faction, warrior=warrior, month=3)
+        )
 
     assert result == WarriorHealthHealed(warrior=warrior, faction=warrior.faction, healed_points=5, month=3)
     warrior.refresh_from_db()
@@ -45,7 +54,9 @@ def test_handle_heal_injured_warrior_caps_healing_at_the_maximum():
     warrior = WarriorFactory(current_health=18, max_health=20)
 
     with mock.patch("apps.warrior.handlers.commands.warrior.random.randrange", return_value=5):
-        result = handle_heal_injured_warrior(context=HealInjuredWarrior(warrior=warrior, month=3))
+        result = handle_heal_injured_warrior(
+            context=HealInjuredWarrior(faction=warrior.faction, warrior=warrior, month=3)
+        )
 
     assert result == WarriorHealthHealed(warrior=warrior, faction=warrior.faction, healed_points=2, month=3)
     warrior.refresh_from_db()
@@ -57,7 +68,9 @@ def test_handle_heal_injured_warrior_at_full_health():
     warrior = WarriorFactory(current_health=20, max_health=20)
 
     with mock.patch("apps.warrior.handlers.commands.warrior.random.randrange", return_value=5):
-        result = handle_heal_injured_warrior(context=HealInjuredWarrior(warrior=warrior, month=3))
+        result = handle_heal_injured_warrior(
+            context=HealInjuredWarrior(faction=warrior.faction, warrior=warrior, month=3)
+        )
 
     assert result is None
 
@@ -72,7 +85,9 @@ def test_handle_heal_injured_warrior_can_roll_the_maximum():
     warrior = WarriorFactory(current_health=1, max_health=20, faction__town__sanctuary=1)
 
     with mock.patch("apps.warrior.handlers.commands.warrior.random.randrange", return_value=8) as mocked_randrange:
-        result = handle_heal_injured_warrior(context=HealInjuredWarrior(warrior=warrior, month=3))
+        result = handle_heal_injured_warrior(
+            context=HealInjuredWarrior(faction=warrior.faction, warrior=warrior, month=3)
+        )
 
     mocked_randrange.assert_called_once_with(1, 9)
     assert result.healed_points == 8
@@ -87,7 +102,76 @@ def test_handle_heal_injured_warrior_heals_further_with_a_larger_sanctuary():
     warrior = WarriorFactory(current_health=1, max_health=30, faction__town__sanctuary=3)
 
     with mock.patch("apps.warrior.handlers.commands.warrior.random.randrange", return_value=1) as mocked_randrange:
-        handle_heal_injured_warrior(context=HealInjuredWarrior(warrior=warrior, month=3))
+        handle_heal_injured_warrior(context=HealInjuredWarrior(faction=warrior.faction, warrior=warrior, month=3))
 
     # A Great Sanctuary reaches 20 points, against the 4 a town without one manages
     mocked_randrange.assert_called_once_with(1, 21)
+
+
+@pytest.mark.django_db
+def test_handle_heal_injured_warrior_mends_a_captive_at_his_captors_sanctuary():
+    """
+    A captive belongs to nobody, so the ceiling can only come from the faction holding him.
+    """
+    captor = FactionFactory(town__sanctuary=1)
+    captive = WarriorFactory(
+        faction=None,
+        savegame=captor.savegame,
+        culture=captor.culture,
+        current_health=0,
+        max_health=20,
+        condition=Warrior.ConditionChoices.CONDITION_UNCONSCIOUS,
+    )
+    captor.captured_warriors.add(captive)
+
+    with mock.patch("apps.warrior.handlers.commands.warrior.random.randrange", return_value=8) as mocked_randrange:
+        result = handle_heal_injured_warrior(context=HealInjuredWarrior(faction=captor, warrior=captive, month=3))
+
+    # A Shrine mends up to 8 points a month, against the 4 of the town the captive no longer has
+    mocked_randrange.assert_called_once_with(1, 9)
+    assert result == WarriorHealthHealed(warrior=captive, faction=captor, healed_points=8, month=3)
+
+
+@pytest.mark.django_db
+def test_handle_heal_injured_warrior_wakes_a_captive_without_freeing_him():
+    """
+    Mending a captive above zero health lifts him out of CONDITION_UNCONSCIOUS, which is what makes
+    him worth recruiting. He stays a prisoner all the same - every roster query goes through the
+    faction he does not have, so being healthy buys him nothing while he is held.
+    """
+    captor = FactionFactory()
+    captive = WarriorFactory(
+        faction=None,
+        savegame=captor.savegame,
+        culture=captor.culture,
+        current_health=0,
+        max_health=20,
+        condition=Warrior.ConditionChoices.CONDITION_UNCONSCIOUS,
+    )
+    captor.captured_warriors.add(captive)
+
+    with mock.patch("apps.warrior.handlers.commands.warrior.random.randrange", return_value=4):
+        handle_heal_injured_warrior(context=HealInjuredWarrior(faction=captor, warrior=captive, month=3))
+
+    captive.refresh_from_db()
+    assert captive.condition == Warrior.ConditionChoices.CONDITION_HEALTHY
+    assert list(captor.captured_warriors.all()) == [captive]
+
+
+@pytest.mark.django_db
+def test_handle_recruit_captured_warrior_keeps_the_health_he_was_mended_to():
+    """
+    Recruiting is the moment a captive rejoins a roster, not a second course of treatment: the
+    months in the cell already brought him back, and taking him on adds nothing to that.
+    """
+    captor = FactionFactory()
+    captive = WarriorFactory(
+        faction=None, savegame=captor.savegame, culture=captor.culture, current_health=20, max_health=20
+    )
+    captor.captured_warriors.add(captive)
+
+    result = handle_recruit_captured_warrior(context=RecruitCapturedWarrior(warrior=captive, faction=captor, month=3))
+
+    assert result == WarriorRecruited(warrior=captive, faction=captor, recruitment_price=0, month=3)
+    captive.refresh_from_db()
+    assert captive.current_health == 20


### PR DESCRIPTION
## What the story asked for

A warrior held prisoner never healed. Capture clears `warrior.faction`, both monthly recovery sweeps walk
`context.faction.warriors`, and a captive is on nobody's roster — so a man taken unconscious sat at the
health the blow that felled him left him at, for as long as he was held. That made holding a captive
strictly worse than selling him, and the captive/enslave choice on the warrior card had one sensible
answer.

## What this builds

**A captive heals at his captor's sanctuary, at the same rate as that faction's own warriors.**
`handle_determine_injured_warriors` now selects the faction's own roster *and* the captives it holds. A
captive belongs to exactly one captor and the sweep runs once per faction per month, so every captive is
reached exactly once with no double-healing.

**The holding faction rides on the command.** The issue left two routes open for getting it to
`handle_heal_injured_warrior`, which read both the sanctuary ceiling and the event's faction off
`warrior.faction` — `None` for a captive. `HealInjuredWarrior` gained a `faction` field rather than the
handler querying `Faction.objects.filter(captured_warriors=…)`: the command is constructed in exactly one
place, and that place is the captor's own sweep, which already holds the faction. It costs no extra query
per captive and *removes* the `None` branch instead of adding one. `WarriorHealthHealed` is therefore
never stamped with `None`, so `handle_create_player_month_log` cannot raise on `context.faction.savegame`
and roll the whole month back.

**Morale does not recover while a warrior is held**, as decided in the issue. The morale sweep is
unchanged and now carries a comment saying the omission is chosen — `handle_replenish_warrior_morale`
refills to the *maximum* unconditionally, and a month in an enemy cell restoring a man's spirit reads
wrong. The accepted consequence is that a long-held captive is recruited near zero morale and routs
early; #43 owns whether he comes back from that.

No new message, no new handler, no new balance number: the existing chain `FactionMonthPrepared →
DetermineInjuredWarriors → HealInjuredWarrior → WarriorHealthHealed → CreatePlayerMonthLog` carries it.
The `{# todo: captured warriors never heal HP #}` in the captured-warrior list is gone with the defect.

Closes #50

## Tests

Every branch the issue lists is pinned, including the side effect it asked to nail down rather than leave
implicit: healing a captive above zero leaves him `CONDITION_HEALTHY` while still in `captured_warriors`.
The month-log player/rival guard is the existing one and keeps its existing tests — what used to break
there was `faction=None`, and the sweep test pins that the captor now rides on the command.

**One branch the issue lists has no test, deliberately.** *"Recruiting a captive who has already been
healed still works and does not double-heal him"* turns out to be structurally unfalsifiable:
`handle_recruit_captured_warrior` never touches health, and the sweep's `Q(faction=…) | Q(id__in=…)`
compiles `id__in` to a subquery, so a warrior on both branches at once comes back exactly once. A test
written at the sweep survives the mutation it should catch — deleting `remove_captive` from the recruit
handler leaves it green — and the join form does not duplicate either, because duplicating needs two
captor rows, which #30 forbids. A test that cannot fail is worse than none, so there is none, and this
paragraph is the record of why.

## CI

`pre-commit run --all-files` and `uv run pytest --cov` behind the 100% branch gate: **both green, first
round**, and green again after the test removal below — coverage held at 100%, which is the independent
confirmation that the removed test covered nothing the rest of the suite did not.

## Review coverage

Sharded review over 238 changed lines. **All four lenses ran, one found something.**

- *Correctness and message-bus wiring* — complete, no finding. Verified that no `None` faction can reach
  `handle_create_player_month_log` and that the handler placement is legal.
- *Data layer, savegame scoping, migrations* — complete, no finding. Verified the new query cannot return
  duplicate rows and that no migration is owed.
- *Test honesty and coverage substance* — complete, **one finding at confidence 85, fixed.** A test
  asserting that recruiting does not reset a captive's health passed with the entire feature reverted,
  because the handler it called never touches health. Removed, and the branch it claimed to cover is
  documented above as unfalsifiable rather than quietly re-covered.
- *Spec conformance and simplification* — complete, no finding. Walked the issue's "Branches to cover"
  list item by item (9 of 10 tested, the tenth being the gap above), confirmed both "Decided" paragraphs
  are implemented exactly as decided with no extra modifier and no new balance constant, and confirmed the
  out-of-scope list is untouched. It was also asked to attack the unfalsifiability reasoning rather than
  accept it, and it holds — adding that even a duplicate M2M through-row cannot produce a duplicate
  warrior, since `id__in` sits in a `WHERE` clause with no fan-out join at the outer level.

The last two lenses were initially dropped by the diff-size rule (238 lines buys two shards, taken in rank
order) and run separately afterwards. On a diff where 196 of 222 added lines are tests, the test lens was
the cheapest to skip and the most expensive to have skipped — it produced the round's only finding. Worth
noting for the next story that lands in this shape.

## Content review

Played in a real browser on a throwaway database: the six-step baseline journey, a ten-step story journey
and a three-step rival-captor check. **All passed, no fix round needed.**

A captive was seeded at 2/20 health, unconscious (the state a capture leaves behind — the precondition,
never the effect). Over ten finished months his health climbed to 20/20 and stopped there, the last log
line reading "healed 2 HP" — the exact remainder rather than a full roll — with no further line once he
was full. His morale never moved off 3/20. He turned `Healthy` while still listed under "Captured
warriors", and recruiting him then put him on the roster at 20/20 with max morale cut to 15. A rival's
captive healed on the same terms, and the player's month log carried no line about him.

43 requests, all 200 (plus two redirects), no traceback in the server log, no console error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
