### PR TITLE
The training regimen is not a player-only activity

### DIFF
--- a/apps/month/messages/events/month.py
+++ b/apps/month/messages/events/month.py
@@ -28,9 +28,13 @@ class PlayerMonthPrepared(Event):
     """
     A new month has begun for the human player specifically.
 
-    Only for the things a rival genuinely has no equivalent of: the town economy, the training
-    regimen, the message log. A faction of the savegame gets a FactionMonthPrepared as well, so
-    nothing here needs repeating for the player.
+    Only for the things a rival genuinely has no equivalent of: the town economy and the message
+    log. A faction of the savegame gets a FactionMonthPrepared as well, so nothing here needs
+    repeating for the player.
+
+    The training regimen sits here too, and does not belong: every faction owns a Training row
+    from NewFactionCreated on, so training is a player-only activity by registration only.
+    Moving it is #48.
 
     Moving a handler from here to FactionMonthPrepared is how a player-only activity becomes
     something rivals do too - the field names match so that the move is the whole change.


### PR DESCRIPTION
`PlayerMonthPrepared` listed the training regimen among the things "a rival genuinely has no
equivalent of". That is not true: `handle_create_training_for_faction` fires on
`NewFactionCreated`, so every faction — rivals included — has owned a `Training` row since the
savegame was created. Training is player-only by registration, not by design.

The docstring is the normative statement of what the two month events are for, so the wrong
line there is the kind that gets trusted. #48 owns the actual move to `FactionMonthPrepared`;
this only stops the seam from arguing against it.

Docstring only — no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)