### PR TITLE
A warrior who routs without a scratch never fights again

### DIFF
--- a/apps/faction/tests/handlers/commands/test_faction.py
+++ b/apps/faction/tests/handlers/commands/test_faction.py
@@ -417,6 +417,30 @@ def test_handle_determine_warriors_with_reduced_morale_passes_over_captives():
 
 
 @pytest.mark.django_db
+def test_handle_determine_warriors_with_reduced_morale_picks_up_a_fleeing_warrior():
+    """
+    The half of the rally this sweep owns. Restoring the condition further down the chain only ever
+    helps if the man who routed is in this list at all, and a warrior who fled without a scratch is
+    in no other one - the healing sweep wants the wounded, and he is not.
+    """
+    faction = FactionFactory()
+    fleeing_warrior = WarriorFactory(
+        faction=faction,
+        current_morale=0,
+        max_morale=20,
+        condition=Warrior.ConditionChoices.CONDITION_FLEEING,
+    )
+
+    result = handle_determine_warriors_with_reduced_morale(
+        context=DetermineWarriorsWithReducedMorale(faction=faction, month=3)
+    )
+
+    assert result == FactionWarriorsWithReducedMoraleDetermined(
+        faction=faction, warrior_list=[fleeing_warrior], month=3
+    )
+
+
+@pytest.mark.django_db
 def test_handle_create_factions_for_new_savegame_starts_with_the_player_faction():
     savegame = SavegameFactory()
     culture = CultureFactory()

--- a/apps/skirmish/managers/warrior.py
+++ b/apps/skirmish/managers/warrior.py
@@ -84,13 +84,33 @@ class WarriorManager(manager.Manager):
         self.filter(armor=item).update(armor=None)
 
     def replenish_current_morale(self, *, obj, recovered_morale_points: int):
+        """
+        Give the morale back, and with it the nerve to fight again.
+
+        A rout is the one condition morale owns, so this owns the way out of it the same way
+        "replenish_current_health" owns the way out of unconsciousness. Without the condition, a
+        warrior who fled without a scratch ended the month at full morale and still "FLEEING": the
+        healing sweep only looks at the wounded, so the one method that could have cleared him never
+        ran on him, and he drew salary for the rest of the game without ever fighting again.
+
+        Only the fleeing rally. An unconscious man's way back is the health path - and he reaches
+        this method every month, because the morale sweep excludes only the dead - while a dead one
+        has no way back at all, so a bare "his morale is up, so he is healthy" would wake the first
+        and resurrect the second.
+
+        Rallied to zero is not rallied, which is why the morale is asked about as well as the
+        condition.
+        """
         obj.refresh_from_db()
         obj.current_morale += recovered_morale_points
 
         if obj.current_morale > obj.max_morale:
             obj.current_morale = obj.max_morale
 
-        obj.save(update_fields=("current_morale",))
+        if obj.current_morale > 0 and obj.is_fleeing:
+            obj.condition = obj.ConditionChoices.CONDITION_HEALTHY
+
+        obj.save(update_fields=("current_morale", "condition"))
 
         return obj
 

--- a/apps/skirmish/tests/managers/test_warrior.py
+++ b/apps/skirmish/tests/managers/test_warrior.py
@@ -170,6 +170,83 @@ def test_replenish_current_morale_caps_at_the_maximum():
 
 
 @pytest.mark.django_db
+def test_replenish_current_morale_rallies_a_fleeing_warrior():
+    """
+    A rout with no wound in it is a normal way for a fight to end, and this is the only method that
+    can clear it - the healing sweep never sees a warrior who is already at full health.
+    """
+    warrior = WarriorFactory(current_morale=0, max_morale=20, condition=Warrior.ConditionChoices.CONDITION_FLEEING)
+
+    result = Warrior.objects.replenish_current_morale(obj=warrior, recovered_morale_points=20)
+
+    assert result.current_morale == 20
+    assert result.condition == Warrior.ConditionChoices.CONDITION_HEALTHY
+
+
+@pytest.mark.django_db
+def test_replenish_current_morale_rallies_a_fleeing_warrior_despite_his_wounds():
+    """
+    The rally does not wait on the health path: his nerve and his wounds are mended separately, and
+    a man who has both is not left running until the second one is done.
+    """
+    warrior = WarriorFactory(
+        current_morale=0,
+        max_morale=20,
+        current_health=5,
+        max_health=20,
+        condition=Warrior.ConditionChoices.CONDITION_FLEEING,
+    )
+
+    result = Warrior.objects.replenish_current_morale(obj=warrior, recovered_morale_points=20)
+
+    assert result.current_health == 5
+    assert result.condition == Warrior.ConditionChoices.CONDITION_HEALTHY
+
+
+@pytest.mark.django_db
+def test_replenish_current_morale_leaves_an_unconscious_warrior_unconscious():
+    """
+    The morale sweep excludes only the dead, so an unconscious warrior below his maximum reaches
+    this method every month. Waking him here would take the healing sweep's decision away from it.
+    """
+    warrior = WarriorFactory(
+        current_morale=0,
+        max_morale=20,
+        current_health=-5,
+        max_health=20,
+        condition=Warrior.ConditionChoices.CONDITION_UNCONSCIOUS,
+    )
+
+    result = Warrior.objects.replenish_current_morale(obj=warrior, recovered_morale_points=20)
+
+    assert result.current_morale == 20
+    assert result.condition == Warrior.ConditionChoices.CONDITION_UNCONSCIOUS
+
+
+@pytest.mark.django_db
+def test_replenish_current_morale_leaves_a_dead_warrior_dead():
+    warrior = WarriorFactory(current_morale=0, max_morale=20, condition=Warrior.ConditionChoices.CONDITION_DEAD)
+
+    result = Warrior.objects.replenish_current_morale(obj=warrior, recovered_morale_points=20)
+
+    assert result.condition == Warrior.ConditionChoices.CONDITION_DEAD
+
+
+@pytest.mark.django_db
+def test_replenish_current_morale_does_not_rally_a_warrior_whose_morale_is_still_zero():
+    """
+    Rallied to nothing is not rallied - a man handed back zero morale would rout again on the first
+    blow of the next fight.
+    """
+    warrior = WarriorFactory(current_morale=0, max_morale=0, condition=Warrior.ConditionChoices.CONDITION_FLEEING)
+
+    result = Warrior.objects.replenish_current_morale(obj=warrior, recovered_morale_points=0)
+
+    assert result.current_morale == 0
+    assert result.condition == Warrior.ConditionChoices.CONDITION_FLEEING
+
+
+@pytest.mark.django_db
 def test_increase_morale_adds_the_gained_points():
     warrior = WarriorFactory(current_morale=10, max_morale=20)
 


### PR DESCRIPTION
A warrior whose morale ran out was set to `CONDITION_FLEEING` and nothing ever set him back. The only
line that restored `CONDITION_HEALTHY` lived in `replenish_current_health`, which runs on warriors the
monthly sweep picks by `current_health__lt=max_health` — so a warrior who fled **without being wounded**
was in no set that could clear him. The morale sweep did reach him and refilled him to the maximum, but
`replenish_current_morale` wrote `update_fields=("current_morale",)` and never touched `condition`.

He ended the month at full health, full morale and still `FLEEING`, and stayed there: no quest, no
attack, no defence, no training, full salary for the rest of the game.

Closes #43

## What this does

`replenish_current_morale` now owns the way out of a rout, the way `replenish_current_health` already
owns the way out of unconsciousness:

```python
if obj.current_morale > 0 and obj.is_fleeing:
    obj.condition = obj.ConditionChoices.CONDITION_HEALTHY

obj.save(update_fields=("current_morale", "condition"))
```

Both halves of the guard are load-bearing:

- **`is_fleeing`** — the issue's explicit warning, and not theoretical: the morale sweep excludes only
  `CONDITION_DEAD`, so an unconscious warrior below his maximum morale reaches this method every month.
  A bare "his morale is up, so he is healthy" would wake him and resurrect the dead man behind him.
- **`current_morale > 0`** — rallied to zero is not rallied.

Growing `update_fields` is the actual bug: without `"condition"` the write is silently dropped.

No new message, handler or migration — the change does not cross the bus, so the registry tests have
nothing new to prove.

## On the open question

The issue left open whether a rout should cost something. **It costs nothing here**, by the maintainer's
call, and the balance change gets its own issue. Worth recording why the obvious version of it is not a
one-liner: a percentage off `max_morale` re-opens this very bug, because `reduce_max_morale` floors at
zero and `current_morale__lt=F("max_morale")` never selects a warrior whose max is zero. That version
needs a floor above zero or the warrior wedges again.

## CI

Both gates green, first round. `pre-commit run --all-files` clean; 550 tests pass at **100% branch
coverage**.

Six tests added. Five on the manager — rallies at full health, rallies despite wounds, leaves the
unconscious alone, leaves the dead alone, does not rally a man whose morale is still zero — and one on
`handle_determine_warriors_with_reduced_morale` proving a fleeing warrior is in the sweep at all, which
is the half of the chain the fix depends on and the test that fails if someone later adds
`filter_healthy()` there. The two rally tests were confirmed to fail against the unpatched manager.

## Review coverage

Two lenses run concurrently against `git diff main...HEAD`, **no findings at confidence 80 or above**.

- **01 Correctness** — traced the one real risk here, that adding `"condition"` to `update_fields` could
  clobber a condition written elsewhere in the same transaction, through both orderings of
  `HealInjuredWarrior` and `ReplenishWarriorMorale` for a warrior wounded *and* fleeing in one month.
  Both methods `refresh_from_db()` before deciding and both only ever write `CONDITION_HEALTHY`, so
  whichever runs second re-reads the first's committed value and writes the same thing. No clobber.
- **03 Tests** — three candidates, all refuted or scored below the bar.

**Skipped: 02 data layer and 04 conformance.** The diff is 123 lines, which takes a single shard by the
sharding table. Cost of skipping 02 is low — no model field, migration, view or queryset in the diff, so
the bugs it hunts are not reachable. Conformance was settled with the maintainer before implementation.
Lens 03 was run *in addition* to the prescribed single shard because 99 of the 123 changed lines are
tests, which is not lens 01's territory.

## Content review

Walked in a real browser on a throwaway database: fresh savegame, all six nav pages, two months played,
then the rout seeded on the starting warrior (`FLEEING`, morale 0, health full — the precondition; the
effect was played, not seeded).

- Before: faction detail reads `19/19` health, `0/6` morale, **Fleeing**, and his training progress sits
  frozen at strength `10/0` across the month.
- After one Finish month: `19/19`, `6/6`, **Healthy**, and the log carries "Morale of warrior Ricky was
  replenished to the maximum."
- After one more: strength progress moves `0 → 8`. **He trains again** — the issue's actual complaint,
  undone end to end.

13 of 13 steps pass, 0 console errors, 0 5xx, no traceback in the server log. No fix rounds needed.

One caveat stated rather than papered over: the `is_fleeing` guard itself is **not** cleanly observable
in a browser. An unconscious warrior always has `current_health <= 0`, so he is in the healing sweep the
same month, and no click can separate "the morale path left him alone" from "the health path had not got
to him yet". That half is covered by the manager unit tests.

## Out of scope, worth follow-ups

- **A warrior captured while fleeing still never rallies.** The morale sweep reads
  `context.faction.warriors`, and capture clears `warrior.faction`, so a captive never reaches this
  method at all — and the exclusion is deliberate, on the reasoning that a month in an enemy cell should
  not restore a man's spirit. Sound reasoning, but the side effect is the same freeze this issue
  describes, through a different door.
- **The training overview lists warriors who will not be trained.** `TrainingListView` renders
  `faction.warriors` unfiltered while the handler trains only `CONDITION_HEALTHY`. Pre-existing and
  untouched here, but it is why this bug stayed invisible to players: the screen that should have shown
  a warrior dropping out of the training kept listing him as though nothing had changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
