### PR TITLE
Level up increases warrior stats

### DIFF
--- a/apps/faction/templates/faction/warrior/components/pub_warrior_card.html
+++ b/apps/faction/templates/faction/warrior/components/pub_warrior_card.html
@@ -8,6 +8,7 @@
             <div class="uk-width-expand">
                 <h3 class="uk-card-title uk-margin-remove-bottom">{{ warrior.name }}</h3>
                 <p class="uk-text-meta uk-margin-remove-top">
+                    <i class="fa-solid fa-award"></i> <i>Level {{ warrior.level }}</i>&nbsp;
                     <i class="fa-solid fa-layer-group"></i> <i>{{ warrior.experience }} XP</i>&nbsp;
                     <i class="fa-solid fa-coins"></i> <i>{{ warrior.monthly_salary }}</i>&nbsp;
                     <i class="fa-solid fa-heart"></i>

--- a/apps/skirmish/handlers/commands/warrior.py
+++ b/apps/skirmish/handlers/commands/warrior.py
@@ -7,8 +7,10 @@ from apps.skirmish.messages.commands.warrior import ReduceHealth, ReduceMorale
 from apps.skirmish.messages.events.warrior import (
     LastUsedSkirmishActionStored,
     WarriorGainedExperience,
+    WarriorGainedLevel,
     WarriorGainedMorale,
     WarriorHasFled,
+    WarriorImprovedStats,
     WarriorLostMorale,
     WarriorWasCaptured,
     WarriorWasIncapacitated,
@@ -160,10 +162,54 @@ def handle_warrior_increasing_morale(*, context: warrior.IncreaseMorale) -> list
 
 @message_registry.register_command(command=warrior.IncreaseExperience)
 def handle_warrior_increasing_experience(*, context: warrior.IncreaseExperience) -> list[Event] | Event:
+    """
+    Books the experience, and announces every level threshold it carried the warrior across.
+
+    The level before the gain is worked out from the value after it, because there is no reliable
+    "before" left to read: increase_experience refreshes from the database and then adds, so the
+    instance the caller was holding may have been stale. Subtracting what the manager was told to add
+    from what it ended up with gives the old total whatever the caller had. Asking a later event
+    handler instead is not an option either - strict mode blocks database access there.
+
+    One event per level crossed rather than one for the crossing. A gain that spans two thresholds has
+    to grow the warrior twice and read as two lines in the log; clamping to a single level-up would
+    quietly swallow the second.
+    """
     context.warrior = Warrior.objects.increase_experience(obj=context.warrior, experience=context.increased_experience)
 
-    return WarriorGainedExperience(
+    previous_level = Warrior.level_for(experience=context.warrior.experience - context.increased_experience)
+
+    message_list = [
+        WarriorGainedExperience(
+            skirmish=context.skirmish,
+            warrior=context.warrior,
+            gained_experience=context.increased_experience,
+        )
+    ]
+
+    for level in range(previous_level + 1, context.warrior.level + 1):
+        message_list.append(
+            WarriorGainedLevel(
+                skirmish=context.skirmish,
+                warrior=context.warrior,
+                level=level,
+            )
+        )
+
+    return message_list
+
+
+@message_registry.register_command(command=warrior.IncreaseWarriorStatsOnLevelUp)
+def handle_increase_warrior_stats_on_level_up(*, context: warrior.IncreaseWarriorStatsOnLevelUp) -> list[Event] | Event:
+    gains = Warrior.objects.apply_level_up_growth(obj=context.warrior)
+
+    return WarriorImprovedStats(
         skirmish=context.skirmish,
         warrior=context.warrior,
-        gained_experience=context.increased_experience,
+        gained_strength=gains["strength"],
+        gained_dexterity=gains["dexterity"],
+        gained_max_health=gains["max_health"],
+        gained_max_morale=gains["max_morale"],
+        gained_salary=gains["monthly_salary"],
+        new_monthly_salary=context.warrior.monthly_salary,
     )

--- a/apps/skirmish/handlers/events/battle_history.py
+++ b/apps/skirmish/handlers/events/battle_history.py
@@ -113,6 +113,28 @@ def handle_warrior_gained_experience(*, context: warrior.WarriorGainedExperience
     )
 
 
+@message_registry.register_event(event=warrior.WarriorGainedLevel)
+def handle_warrior_gained_level(*, context: warrior.WarriorGainedLevel) -> Command:
+    return CreateBattleHistory(
+        skirmish=context.skirmish,
+        message=f"{context.warrior} reached level {context.level}.",
+    )
+
+
+@message_registry.register_event(event=warrior.WarriorImprovedStats)
+def handle_warrior_improved_stats(*, context: warrior.WarriorImprovedStats) -> Command:
+    """
+    The wage rise is told to the player at the moment it happens. A bill that grows silently is one he
+    discovers as an unexplained shortfall a month later.
+    """
+    return CreateBattleHistory(
+        skirmish=context.skirmish,
+        message=f"{context.warrior} grew stronger: strength +{context.gained_strength}, "
+        f"dexterity +{context.gained_dexterity}, health +{context.gained_max_health}, "
+        f"morale +{context.gained_max_morale} — and now costs {context.new_monthly_salary} silver a month.",
+    )
+
+
 @message_registry.register_event(event=transaction.WarriorDroppedSilver)
 def handle_warrior_dropped_silver(*, context: transaction.WarriorDroppedSilver) -> Command:
     return CreateBattleHistory(

--- a/apps/skirmish/handlers/events/warrior.py
+++ b/apps/skirmish/handlers/events/warrior.py
@@ -7,6 +7,7 @@ from apps.skirmish.messages.commands.warrior import (
     CaptureWarrior,
     IncreaseExperience,
     IncreaseMorale,
+    IncreaseWarriorStatsOnLevelUp,
     ReduceHealth,
     ReduceMorale,
     ReduceMoraleOfRemainingWarriors,
@@ -90,6 +91,14 @@ def handle_experience_gain_on_warrior_incapacitation(
         warrior=context.by_warrior,
         increased_experience=gained_experience,
     )
+
+
+@message_registry.register_event(event=warrior.WarriorGainedLevel)
+def handle_stat_growth_on_warrior_level_up(*, context: warrior.WarriorGainedLevel) -> Command:
+    # The writing happens in the command handler rather than here, for the same reason
+    # ReduceMoraleOfRemainingWarriors exists rather than the morale drop happening inline: an event
+    # handler reacts, it does not touch the database
+    return IncreaseWarriorStatsOnLevelUp(skirmish=context.skirmish, warrior=context.warrior)
 
 
 @message_registry.register_event(event=warrior.WarriorDefendedAllDamage)

--- a/apps/skirmish/managers/warrior.py
+++ b/apps/skirmish/managers/warrior.py
@@ -139,6 +139,42 @@ class WarriorManager(manager.Manager):
 
         return obj
 
+    def apply_level_up_growth(self, *, obj) -> dict[str, int]:
+        """
+        Grow everything a level touches by LEVEL_UP_GROWTH, and return what each one gained.
+
+        Only the maxima, never the current values. Unlike training, experience arrives *during* a
+        skirmish - handle_experience_gain_on_warrior_incapacitation fires the moment somebody drops -
+        so raising current_health here would top a warrior up mid-battle and make winning harder the
+        cheapest way to survive. The warrior reads as wounded against his new ceiling instead, which
+        is what handle_progress_warrior_training already does with max_morale.
+
+        Every gain is floored at one point. A tenth of a small attribute rounds to nothing: round(v *
+        0.1) is 0 for every v from 1 to 5, five included, because Python rounds halves to even. The
+        fyrd generator sits at STATS_MU = 5 and MORALE_MU = 5, so a levy would otherwise level up,
+        gain a single hit point off his health, and charge more for it. Same reasoning and same shape
+        as max(1, morale_at_stake) in handle_morale_change_on_warrior_defends_all_damage.
+
+        The *_progress columns are deliberately not involved. They belong to training, which fills and
+        resets them, so keeping a fractional remainder there would mean a level-up eats a month of
+        training and a month of training triggers level-up growth. Levels round per event.
+        """
+        # The refresh matters twice over: it takes the authoritative values, and it is also what turns
+        # a generated warrior's float attributes into the integers the arithmetic below assumes
+        obj.refresh_from_db()
+
+        grown_fields = ("strength", "dexterity", "max_health", "max_morale", "monthly_salary")
+        gains = {field: max(1, round(getattr(obj, field) * self.model.LEVEL_UP_GROWTH)) for field in grown_fields}
+
+        for field, gain in gains.items():
+            setattr(obj, field, getattr(obj, field) + gain)
+
+        # Only the five fields touched above: a full save would write back everything else this
+        # instance still holds from before
+        obj.save(update_fields=grown_fields)
+
+        return gains
+
     def get_monthly_salary_for_faction(self, *, faction) -> int:
         """
         Calculate the salary of all warriors working for "faction" not being dead.

--- a/apps/skirmish/messages/commands/warrior.py
+++ b/apps/skirmish/messages/commands/warrior.py
@@ -53,4 +53,11 @@ class IncreaseMorale(Command):
 class IncreaseExperience(Command):
     skirmish: Skirmish
     warrior: Warrior
-    increased_experience: float
+    # An int, because a fractional gain would put the level thresholds off by a rounding error
+    increased_experience: int
+
+
+@dataclass(kw_only=True)
+class IncreaseWarriorStatsOnLevelUp(Command):
+    skirmish: Skirmish
+    warrior: Warrior

--- a/apps/skirmish/messages/events/warrior.py
+++ b/apps/skirmish/messages/events/warrior.py
@@ -97,3 +97,26 @@ class WarriorGainedExperience(Event):
     skirmish: Skirmish
     warrior: Warrior
     gained_experience: int
+
+
+@dataclass(kw_only=True)
+class WarriorGainedLevel(Event):
+    skirmish: Skirmish
+    warrior: Warrior
+    level: int
+
+
+@dataclass(kw_only=True)
+class WarriorImprovedStats(Event):
+    skirmish: Skirmish
+    warrior: Warrior
+    gained_strength: int
+    gained_dexterity: int
+    gained_max_health: int
+    gained_max_morale: int
+    gained_salary: int
+    # The wage *after* the growth, carried rather than read back off the warrior when the log line is
+    # written. Every message in a level-up chain holds the same instance, so a gain crossing two
+    # thresholds grows it twice before either log handler runs - and both lines would then quote the
+    # wage the second growth left behind.
+    new_monthly_salary: int

--- a/apps/skirmish/models/warrior.py
+++ b/apps/skirmish/models/warrior.py
@@ -1,3 +1,5 @@
+from math import isqrt
+
 from django.db import models
 
 from apps.common.domain.dice import DiceNotation
@@ -15,6 +17,14 @@ from apps.skirmish.services.skirmish.skirmish_action_decision import SkirmishAct
 class Warrior(models.Model):
     NO_WEAPON_ATTACK = "1d3"
     NO_ARMOR_DEFENSE = "1d3"
+
+    # Reaching level N costs (N - 1) squared times XP_LEVEL_BASE - 100, 400, 900, 1600 - so every level takes
+    # longer than the one before it and a veteran does not run away with it. Quadratic rather than
+    # anything steeper because isqrt inverts it in one integer expression: no loop walking the
+    # levels, and no float to round the wrong way at a threshold.
+    XP_LEVEL_BASE = 100
+    # What every level adds to the four attributes and to the salary alike
+    LEVEL_UP_GROWTH = 0.1
 
     class ConditionChoices(models.IntegerChoices):
         CONDITION_HEALTHY = 1, "Healthy"
@@ -113,6 +123,36 @@ class Warrior(models.Model):
     @property
     def slavery_selling_price(self) -> int:
         return int(self.recruitment_price / 2)
+
+    @staticmethod
+    def level_for(*, experience: int) -> int:
+        """
+        The level a given amount of experience buys, as a staticmethod so a handler can ask for the
+        level of a number rather than of an instance.
+
+        Derived rather than stored: a column would need a backfill for every warrior generated with
+        experience already, and would then be free to drift out of step with the experience it is
+        supposed to describe.
+
+        Coerced to an int because a freshly generated warrior does not hold one. BaseWarriorGenerator
+        rolls "random.gauss" and hands the float straight to "objects.create", and Django does not
+        re-read after a create - so the database has an integer while the in-memory instance still has
+        30.4, and "isqrt(30.4 // 100)" raises. That is every warrior in the pub and every leader on the
+        turn a savegame is created.
+        """
+        return isqrt(int(experience) // Warrior.XP_LEVEL_BASE) + 1
+
+    @property
+    def level(self) -> int:
+        return self.level_for(experience=self.experience)
+
+    @property
+    def experience_for_next_level(self) -> int:
+        """
+        The threshold the next level sits behind, so a level can be shown as progress towards
+        something rather than as a number that appears from nowhere on a battlefield.
+        """
+        return self.level**2 * self.XP_LEVEL_BASE
 
     def get_skirmish_actions(self) -> list[tuple]:
         # TODO (#52): show only the ones the warrior has depending on his level

--- a/apps/skirmish/templates/skirmish/warrior/components/warrior_card.html
+++ b/apps/skirmish/templates/skirmish/warrior/components/warrior_card.html
@@ -5,6 +5,9 @@
         <h3 class="uk-card-title">{{ warrior.name }}</h3>
         <ul class="uk-subnav uk-subnav-divider uk-margin-remove-top">
             <li>{{ warrior.faction }}</li>
+            {# The level goes on the card in the fight because this is where a level-up is actually #}
+            {# witnessed: the growth happens mid-skirmish and the log announces it right beside here. #}
+            <li><i class="fa-solid fa-award"></i> Level {{ warrior.level }}</li>
             <li>
                 <div class="uk-margin-top">
                     <progress class="uk-progress progress-green" value="{{ warrior.current_health }}"

--- a/apps/skirmish/tests/handlers/commands/test_warrior.py
+++ b/apps/skirmish/tests/handlers/commands/test_warrior.py
@@ -1,6 +1,7 @@
 import pytest
 
 from apps.skirmish.handlers.commands.warrior import (
+    handle_increase_warrior_stats_on_level_up,
     handle_reduce_morale_of_remaining_warriors,
     handle_reduce_warrior_health,
     handle_warrior_increasing_experience,
@@ -12,14 +13,17 @@ from apps.skirmish.messages.commands.warrior import (
     CaptureWarrior,
     IncreaseExperience,
     IncreaseMorale,
+    IncreaseWarriorStatsOnLevelUp,
     ReduceHealth,
     ReduceMorale,
     ReduceMoraleOfRemainingWarriors,
 )
 from apps.skirmish.messages.events.warrior import (
     WarriorGainedExperience,
+    WarriorGainedLevel,
     WarriorGainedMorale,
     WarriorHasFled,
+    WarriorImprovedStats,
     WarriorLostMorale,
     WarriorWasCaptured,
     WarriorWasIncapacitated,
@@ -247,6 +251,66 @@ def test_handle_warrior_increasing_experience_adds_the_gained_points():
         context=IncreaseExperience(skirmish=skirmish, warrior=warrior, increased_experience=25)
     )
 
-    assert result == WarriorGainedExperience(skirmish=skirmish, warrior=warrior, gained_experience=25)
+    assert result == [WarriorGainedExperience(skirmish=skirmish, warrior=warrior, gained_experience=25)]
     warrior.refresh_from_db()
     assert warrior.experience == 125
+
+
+@pytest.mark.django_db
+def test_handle_warrior_increasing_experience_announces_a_crossed_threshold():
+    skirmish = SkirmishFactory()
+    warrior = WarriorFactory(faction=skirmish.attacking_faction, experience=90)
+
+    result = handle_warrior_increasing_experience(
+        context=IncreaseExperience(skirmish=skirmish, warrior=warrior, increased_experience=25)
+    )
+
+    assert result == [
+        WarriorGainedExperience(skirmish=skirmish, warrior=warrior, gained_experience=25),
+        WarriorGainedLevel(skirmish=skirmish, warrior=warrior, level=2),
+    ]
+
+
+@pytest.mark.django_db
+def test_handle_warrior_increasing_experience_announces_both_of_two_crossed_thresholds():
+    """
+    A gain spanning two thresholds levels the warrior twice, so it has to grow him twice and read as
+    two lines in the log. Clamping to a single level-up would quietly swallow the second.
+    """
+    skirmish = SkirmishFactory()
+    warrior = WarriorFactory(faction=skirmish.attacking_faction, experience=0)
+
+    result = handle_warrior_increasing_experience(
+        context=IncreaseExperience(skirmish=skirmish, warrior=warrior, increased_experience=400)
+    )
+
+    assert result == [
+        WarriorGainedExperience(skirmish=skirmish, warrior=warrior, gained_experience=400),
+        WarriorGainedLevel(skirmish=skirmish, warrior=warrior, level=2),
+        WarriorGainedLevel(skirmish=skirmish, warrior=warrior, level=3),
+    ]
+
+
+@pytest.mark.django_db
+def test_handle_increase_warrior_stats_on_level_up_reports_every_gain():
+    skirmish = SkirmishFactory()
+    warrior = WarriorFactory(
+        faction=skirmish.attacking_faction, strength=10, dexterity=10, max_health=20, max_morale=20, monthly_salary=150
+    )
+
+    result = handle_increase_warrior_stats_on_level_up(
+        context=IncreaseWarriorStatsOnLevelUp(skirmish=skirmish, warrior=warrior)
+    )
+
+    assert result == WarriorImprovedStats(
+        skirmish=skirmish,
+        warrior=warrior,
+        gained_strength=1,
+        gained_dexterity=1,
+        gained_max_health=2,
+        gained_max_morale=2,
+        gained_salary=15,
+        new_monthly_salary=165,
+    )
+    warrior.refresh_from_db()
+    assert warrior.monthly_salary == 165

--- a/apps/skirmish/tests/handlers/events/test_battle_history.py
+++ b/apps/skirmish/tests/handlers/events/test_battle_history.py
@@ -12,8 +12,10 @@ from apps.skirmish.handlers.events.battle_history import (
     handle_log_warrior_takes_damage,
     handle_warrior_dropped_silver,
     handle_warrior_gained_experience,
+    handle_warrior_gained_level,
     handle_warrior_gains_morale,
     handle_warrior_has_fled,
+    handle_warrior_improved_stats,
     handle_warrior_is_captured,
     handle_warrior_lost_morale,
 )
@@ -24,8 +26,10 @@ from apps.skirmish.messages.events.transaction import WarriorDroppedSilver
 from apps.skirmish.messages.events.warrior import (
     WarriorDefendedAllDamage,
     WarriorGainedExperience,
+    WarriorGainedLevel,
     WarriorGainedMorale,
     WarriorHasFled,
+    WarriorImprovedStats,
     WarriorLostMorale,
     WarriorTookDamage,
     WarriorWasCaptured,
@@ -217,6 +221,39 @@ def test_handle_warrior_gained_experience_logs_the_gained_points():
     )
 
     assert result == CreateBattleHistory(skirmish=skirmish, message="Beorn gained 25 experience.")
+
+
+def test_handle_warrior_gained_level_logs_the_new_level():
+    skirmish = SkirmishFactory.build()
+    warrior = WarriorFactory.build(name="Beorn")
+
+    result = handle_warrior_gained_level(context=WarriorGainedLevel(skirmish=skirmish, warrior=warrior, level=4))
+
+    assert result == CreateBattleHistory(skirmish=skirmish, message="Beorn reached level 4.")
+
+
+def test_handle_warrior_improved_stats_logs_the_growth_and_the_new_wage():
+    skirmish = SkirmishFactory.build()
+    warrior = WarriorFactory.build(name="Beorn")
+
+    result = handle_warrior_improved_stats(
+        context=WarriorImprovedStats(
+            skirmish=skirmish,
+            warrior=warrior,
+            gained_strength=1,
+            gained_dexterity=1,
+            gained_max_health=2,
+            gained_max_morale=1,
+            gained_salary=15,
+            new_monthly_salary=165,
+        )
+    )
+
+    assert result == CreateBattleHistory(
+        skirmish=skirmish,
+        message="Beorn grew stronger: strength +1, dexterity +1, health +2, morale +1 — "
+        "and now costs 165 silver a month.",
+    )
 
 
 def test_handle_warrior_dropped_silver_logs_the_loot():

--- a/apps/skirmish/tests/handlers/events/test_warrior.py
+++ b/apps/skirmish/tests/handlers/events/test_warrior.py
@@ -8,11 +8,13 @@ from apps.skirmish.handlers.events.warrior import (
     handle_morale_change_on_warrior_defends_all_damage,
     handle_morale_drop_on_faction_on_warrior_is_out_of_fight,
     handle_reduce_health_and_update_condition,
+    handle_stat_growth_on_warrior_level_up,
 )
 from apps.skirmish.messages.commands.warrior import (
     CaptureWarrior,
     IncreaseExperience,
     IncreaseMorale,
+    IncreaseWarriorStatsOnLevelUp,
     ReduceHealth,
     ReduceMorale,
     ReduceMoraleOfRemainingWarriors,
@@ -20,6 +22,7 @@ from apps.skirmish.messages.commands.warrior import (
 from apps.skirmish.messages.events.skirmish import SkirmishFinished
 from apps.skirmish.messages.events.warrior import (
     WarriorDefendedAllDamage,
+    WarriorGainedLevel,
     WarriorHasFled,
     WarriorTookDamage,
     WarriorWasIncapacitated,
@@ -116,6 +119,17 @@ def test_handle_experience_gain_on_warrior_incapacitation_for_a_killed_warrior()
     )
 
     assert result == IncreaseExperience(skirmish=skirmish, warrior=killer, increased_experience=25)
+
+
+def test_handle_stat_growth_on_warrior_level_up_asks_for_the_growth():
+    skirmish = SkirmishFactory.build()
+    warrior = WarriorFactory.build(faction=skirmish.attacking_faction)
+
+    result = handle_stat_growth_on_warrior_level_up(
+        context=WarriorGainedLevel(skirmish=skirmish, warrior=warrior, level=2)
+    )
+
+    assert result == IncreaseWarriorStatsOnLevelUp(skirmish=skirmish, warrior=warrior)
 
 
 @pytest.mark.django_db

--- a/apps/skirmish/tests/managers/test_warrior.py
+++ b/apps/skirmish/tests/managers/test_warrior.py
@@ -194,3 +194,48 @@ def test_increase_experience_adds_the_gained_points():
     result = Warrior.objects.increase_experience(obj=warrior, experience=25)
 
     assert result.experience == 125
+
+
+@pytest.mark.django_db
+def test_apply_level_up_growth_takes_a_tenth_of_every_grown_value():
+    warrior = WarriorFactory(strength=10, dexterity=10, max_health=20, max_morale=20, monthly_salary=150)
+
+    result = Warrior.objects.apply_level_up_growth(obj=warrior)
+
+    assert result == {"strength": 1, "dexterity": 1, "max_health": 2, "max_morale": 2, "monthly_salary": 15}
+    warrior.refresh_from_db()
+    assert (warrior.strength, warrior.dexterity, warrior.max_health, warrior.max_morale, warrior.monthly_salary) == (
+        11,
+        11,
+        22,
+        22,
+        165,
+    )
+
+
+@pytest.mark.django_db
+def test_apply_level_up_growth_floors_every_gain_at_one_point():
+    """
+    A levy off the fyrd sits at about five strength, five dexterity and five morale, and a tenth of
+    five rounds to zero - Python rounds halves to even. Without the floor he would level up, gain a
+    single hit point off his larger health pool, and charge more for it.
+    """
+    warrior = WarriorFactory(strength=5, dexterity=5, max_health=10, max_morale=5, monthly_salary=150)
+
+    result = Warrior.objects.apply_level_up_growth(obj=warrior)
+
+    assert result == {"strength": 1, "dexterity": 1, "max_health": 1, "max_morale": 1, "monthly_salary": 15}
+
+
+@pytest.mark.django_db
+def test_apply_level_up_growth_leaves_the_current_values_alone():
+    """
+    Experience arrives during a skirmish, so raising current_health along with the maximum would top a
+    warrior up mid-battle and make winning harder the cheapest way to survive a fight.
+    """
+    warrior = WarriorFactory(current_health=5, max_health=20, current_morale=5, max_morale=20, monthly_salary=150)
+
+    Warrior.objects.apply_level_up_growth(obj=warrior)
+
+    warrior.refresh_from_db()
+    assert (warrior.current_health, warrior.current_morale) == (5, 5)

--- a/apps/skirmish/tests/models/test_warrior.py
+++ b/apps/skirmish/tests/models/test_warrior.py
@@ -18,3 +18,43 @@ def test_is_fleeing_for_a_warrior_out_of_morale():
     warrior = WarriorFactory.build(condition=Warrior.ConditionChoices.CONDITION_FLEEING)
 
     assert warrior.is_fleeing is True
+
+
+def test_level_for_an_untested_warrior():
+    assert Warrior.level_for(experience=0) == 1
+
+
+def test_level_for_one_point_short_of_the_first_threshold():
+    assert Warrior.level_for(experience=99) == 1
+
+
+def test_level_for_the_first_threshold():
+    assert Warrior.level_for(experience=100) == 2
+
+
+def test_level_for_one_point_short_of_the_second_threshold():
+    assert Warrior.level_for(experience=399) == 2
+
+
+def test_level_for_the_second_threshold():
+    assert Warrior.level_for(experience=400) == 3
+
+
+def test_level_for_a_float_experience():
+    """
+    A generated warrior holds the float "random.gauss" rolled, because Django does not re-read after a
+    create. "isqrt" refuses one, so the coercion inside is what keeps every warrior in the pub readable.
+    """
+    assert Warrior.level_for(experience=130.7) == 2
+
+
+def test_level_reads_the_warriors_own_experience():
+    warrior = WarriorFactory.build(experience=400)
+
+    assert warrior.level == 3
+
+
+def test_experience_for_next_level_is_the_threshold_ahead():
+    warrior = WarriorFactory.build(experience=100)
+
+    assert warrior.experience_for_next_level == 400

--- a/apps/skirmish/tests/test_flows.py
+++ b/apps/skirmish/tests/test_flows.py
@@ -2,7 +2,9 @@ import pytest
 from queuebie.runner import handle_message
 
 from apps.skirmish.choices.skirmish_action import SkirmishActionChoices
+from apps.skirmish.messages.commands.warrior import IncreaseExperience
 from apps.skirmish.messages.events.warrior import WarriorDefendedAllDamage
+from apps.skirmish.models.battle_history import BattleHistory
 from apps.skirmish.models.warrior import Warrior
 from apps.skirmish.tests.factories.skirmish import SkirmishFactory
 from apps.skirmish.tests.factories.warrior import WarriorFactory
@@ -43,3 +45,43 @@ def test_a_warrior_who_only_turtles_eventually_routs(queuebie_registry):
     exhausted_defender.refresh_from_db()
     assert exhausted_defender.current_morale == 0
     assert exhausted_defender.condition == Warrior.ConditionChoices.CONDITION_FLEEING
+
+
+@pytest.mark.django_db
+def test_a_level_up_is_logged_before_the_growth_it_caused(queuebie_registry):
+    """
+    The two lines a level-up writes, in the order a player has to read them in.
+
+    WarriorGainedLevel has two handlers - the logger and the one that starts the growth - and queuebie
+    runs them in registration order, which is the order autodiscover() walked them: app configs, then
+    os.listdir over handlers/events/. "battle_history.py" sorts before "warrior.py", so the level line
+    is queued before the growth command and the log comes out right. Nothing enforces that ordering,
+    and #40 was this same bug in the other direction, with a rout logged before the morale loss that
+    caused it - so it is asserted here rather than trusted to a directory listing.
+
+    Four hundred points from nothing crosses two thresholds at once, which also proves the second
+    level-up is not swallowed, and that the two growths are told apart: the queue is FIFO, so both
+    growths have already run by the time either line is written, and the wages quoted are 165 and 181
+    only because the event carries the figure rather than reading it back off the shared instance.
+    """
+    skirmish = SkirmishFactory()
+    warrior = WarriorFactory(
+        faction=skirmish.attacking_faction,
+        name="Beorn",
+        experience=0,
+        strength=10,
+        dexterity=10,
+        max_health=20,
+        max_morale=20,
+        monthly_salary=150,
+    )
+
+    handle_message(IncreaseExperience(skirmish=skirmish, warrior=warrior, increased_experience=400))
+
+    assert list(BattleHistory.objects.order_by("id").values_list("message", flat=True)) == [
+        "Beorn gained 400 experience.",
+        "Beorn reached level 2.",
+        "Beorn reached level 3.",
+        "Beorn grew stronger: strength +1, dexterity +1, health +2, morale +2 — and now costs 165 silver a month.",
+        "Beorn grew stronger: strength +1, dexterity +1, health +2, morale +2 — and now costs 181 silver a month.",
+    ]

--- a/apps/warrior/templates/warrior/components/warrior_card.html
+++ b/apps/warrior/templates/warrior/components/warrior_card.html
@@ -8,6 +8,7 @@
             <div class="uk-width-expand">
                 <h3 class="uk-card-title uk-margin-remove-bottom">{{ warrior.name }}</h3>
                 <p class="uk-text-meta uk-margin-remove-top">
+                    <i class="fa-solid fa-award"></i> <i>Level {{ warrior.level }}</i>&nbsp;
                     <i class="fa-solid fa-layer-group"></i> <i>{{ warrior.experience }} XP</i>&nbsp;
                     <i class="fa-solid fa-coins"></i> <i>{{ warrior.monthly_salary }}</i>&nbsp;
                     <i class="fa-solid fa-heart"></i>

--- a/apps/warrior/templates/warrior/warrior_detail.html
+++ b/apps/warrior/templates/warrior/warrior_detail.html
@@ -14,6 +14,16 @@
             <td>{{ object.culture }}</td>
         </tr>
         <tr>
+            <td>Level</td>
+            <td>{{ object.level }}</td>
+        </tr>
+        <tr>
+            <td>Experience</td>
+            {# Against the next threshold rather than on its own, so the level reads as progress #}
+            {# towards something instead of a number appearing from nowhere on a battlefield. #}
+            <td>{{ object.experience }} / {{ object.experience_for_next_level }} XP</td>
+        </tr>
+        <tr>
             <td>Weapon</td>
             <td>
                 {% include 'warrior/components/warrior_field_display.html' with object=object attribute='weapon' field_value=object.weapon %}

--- a/apps/warrior/tests/services/generators/warrior/test_base.py
+++ b/apps/warrior/tests/services/generators/warrior/test_base.py
@@ -4,6 +4,7 @@ import pytest
 
 from apps.faction.models import Culture
 from apps.savegame.tests.factories.savegame import SavegameFactory
+from apps.skirmish.models.warrior import Warrior
 from apps.warrior.services.generators.warrior.fyrd import FyrdWarriorGenerator
 
 
@@ -33,3 +34,19 @@ def test_process_leaves_the_warrior_bare_when_both_rolls_fail():
 
     assert result.weapon is None
     assert result.armor is None
+
+
+@pytest.mark.django_db
+def test_process_leaves_a_warrior_whose_level_can_be_read():
+    """
+    The generated experience is a float and Django does not re-read after a create, so the instance
+    handed back here keeps it while the database holds an integer. "isqrt" refuses a float, and this
+    is every warrior in the pub and every leader on the turn a savegame is created - so the level is
+    asked of a generated warrior here rather than only of a factory-built one.
+    """
+    generator = FyrdWarriorGenerator(culture=Culture.objects.first(), faction=None, savegame_id=SavegameFactory().id)
+
+    result = generator.process()
+
+    assert isinstance(result.experience, float)
+    assert result.level == Warrior.objects.get(pk=result.pk).level


### PR DESCRIPTION
Closes #10

## What the story asked for

Experience already accumulated and already got logged, and then nothing read it. This gives a warrior a
**level derived from that experience**, and makes crossing a threshold grow him — strength, dexterity,
`max_health`, `max_morale` and `monthly_salary`, by ten percent each, never by less than a point. A
warrior who gets better gets dearer by the same percentage, which is what stops levelling being pure
upside.

## What was built

`XP_LEVEL_BASE = 100` and `LEVEL_UP_GROWTH = 0.1` live on `Warrior`. The level is a property over a
`level_for(*, experience)` staticmethod — `isqrt(int(experience) // XP_LEVEL_BASE) + 1` — so reaching
level N costs `(N - 1)²` × the base: 100, 400, 900, 1600. Derived, never stored, so a warrior generated
with experience is simply born at that level with no backfill and no column free to drift.

The chain, per [adding a flow](docs/patterns/adding-a-flow.md):

```
IncreaseExperience (cmd, existing)
  └─ handle_warrior_increasing_experience → [WarriorGainedExperience, WarriorGainedLevel × n]
       ├─ handle_warrior_gained_level            (battle_history) → "Harry reached level 3."
       └─ handle_stat_growth_on_warrior_level_up (events/warrior) → IncreaseWarriorStatsOnLevelUp (cmd)
            └─ handle_increase_warrior_stats_on_level_up → WarriorImprovedStats
                 └─ handle_warrior_improved_stats (battle_history) → "Harry grew stronger: …"
```

The growth itself sits in `Warrior.objects.apply_level_up_growth`, which refreshes, computes the five
values and saves with `update_fields` naming exactly those five. `current_health` and `current_morale`
are never touched: experience arrives *during* a skirmish, so raising the current values would top a
warrior up mid-battle and make winning harder the cheapest way to survive a fight.

The level is on all four surfaces a warrior appears on, including
`apps/skirmish/…/components/warrior_card.html` — the card on screen during a fight, which showed no
experience at all before, and which is where a level-up is actually witnessed. The detail page shows
experience against the next threshold rather than on its own.

Also tightened: `IncreaseExperience.increased_experience` from `float` to `int`.

### One deviation from the story

`WarriorImprovedStats` carries a sixth field, `new_monthly_salary`, alongside the five deltas the story
names. Every message in a level-up chain holds the same `Warrior` instance, and the queue is FIFO, so a
gain crossing two thresholds grows that instance twice before either log handler runs — reading the wage
back off the warrior would have made both lines quote the figure the *second* growth left behind. The
event carries the figure instead. The flow test pins it: 165, then 181.

## CI

`pre-commit run --all-files` green, `uv run pytest --cov` green — **563 passed, 100% branch coverage**
against the `fail_under = 100` gate.

## Review coverage

Three sharded lenses, all three completed, **no findings at confidence 80 or higher**:

- **01 Correctness and message-bus wiring** — hand-traced queuebie's FIFO drain for the two-threshold
  case against the real runner, checked the curve at 0, 99, 100, 399, 400 and on a float, followed the
  shared mutable instance through the whole chain.
- **03 Test honesty and coverage substance** — confirmed no first-party mocking, that each loop-count
  branch has its own test, and that reverting either the `int()` coercion or the `max(1, …)` floor turns
  a specific test red.
- **04 Spec conformance and simplification** — walked every acceptance criterion and all nine traps,
  including both files named `warrior_card.html`.

**Skipped: 02 Data layer, savegame scoping and migrations.** Dropped by shard budget, because the diff
adds no model field, no migration, no view, no queryset and no query in a loop. Its one data-layer
surface — `apply_level_up_growth`'s `save(update_fields=…)` — was read by lens 01 as part of the chain.

## Content review

Walked in a real browser on a throwaway database: baseline (login, savegame, every nav entry, finish
month) plus the story journey across all four level surfaces, then a real skirmish with the warrior
seeded one XP short of level 3.

Round 5 of that fight produced, in order:

```
Nicholas is out of the fight being killed.
Harry gained 25 experience.
Harry reached level 3.
Harry grew stronger: strength +1, dexterity +1, health +2, morale +1 — and now costs 249 silver a month.
```

strength 12→13, dexterity 7→8, max_health 18→20, max_morale 6→7, salary 226→249 — and `current_health`
stayed at 18 against the new ceiling of 20, so winning did not heal him. The fight card swapped to
"Level 3" and 18/20 live. No 4xx or 5xx anywhere in the session.

**One step is a partial:** the monthly salary payment actually rising. The skirmish would not resolve —
the turtling stalemate already documented in `handle_morale_change_on_warrior_defends_all_damage`, which
predates this story — and a month cannot be advanced while one is unresolved. The wage bill was read off
`get_monthly_salary_for_faction()`, the function the payment handler calls: 249, against the 226 the
first month actually paid. The rise is real; the payment was not watched happening.

## Out of scope, worth a follow-up

- **Accepting a quest disarms every htmx control on the page it lands you on — now [#66](https://github.com/GitRon/tettenhall/issues/66).**
  `base.html:138` interpolates Django messages into a JS string literal as `"{{ message|safe }}"`, and
  `apps/quest/views.py:55` wraps the quest title in double quotes, so the literal closes early. The
  resulting SyntaxError discards the whole inline `<script>` block — including the `htmx:configRequest`
  CSRF handler — so every htmx post on that page load returns 403 and the player is told nothing.
  Confirmed in the browser: `typeof NOTIFICATION_TIMEOUT === "undefined"`, `POST /item/39/buy` → 403.
  Pre-existing; nothing in `apps/quest` or `base.html` was touched here.
  *(This PR's content review first logged it as a low-severity lost toast. That was wrong on both the
  cause and the blast radius; #66 carries the corrected analysis.)*
- Per the story, still deferred: a level cap, choosing which attribute to raise, unlocking skirmish
  actions per level (the two TODOs in `get_skirmish_actions()` now have the level they were waiting for),
  nicknames, and re-deriving `recruitment_price`/`slavery_selling_price` from grown stats.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

