### PR TITLE
A quote in a message no longer disarms the page it lands on

### DIFF
--- a/apps/common/templates/base.html
+++ b/apps/common/templates/base.html
@@ -133,10 +133,17 @@
         }
     });
 
+    {# Two sinks, two filters, and both are load-bearing. "escapejs" is the one for this position: a #}
+    {# message holding a double quote closes the string literal, and a SyntaxError costs the whole #}
+    {# block above - the CSRF header, the notification listener and the 5xx toast all stop being #}
+    {# registered. "escape" is for the sink underneath: UIkit inserts "message" as HTML, so a "<" #}
+    {# would otherwise be parsed as markup rather than shown. "level_tag" is a fixed vocabulary #}
+    {# today, but it sits in the same position, so it is escaped too rather than left to be worked #}
+    {# out again later. #}
     {% for message in messages %}
         UIkit.notification({
-            message: "{{ message|safe }}",
-            status: "{{ message.level_tag }}",
+            message: "{{ message|escape|escapejs }}",
+            status: "{{ message.level_tag|escapejs }}",
             pos: 'top-center',
             timeout: NOTIFICATION_TIMEOUT,
         });

--- a/apps/common/tests/test_base_template.py
+++ b/apps/common/tests/test_base_template.py
@@ -1,11 +1,15 @@
 """
-Tests for the navbar in base.html, which every authenticated page extends.
+Tests for base.html, which every authenticated page extends.
 
-A template error here is not confined to one view: it turns the whole site into a 500 for the
-affected user, which is why the status code alone is worth asserting.
+Nothing that breaks here is confined to one view. A template error turns the whole site into a 500
+for the affected user, which is why the status code alone is worth asserting; a broken inline script
+block disarms every htmx control on the page, silently.
 """
 
 import pytest
+from django.contrib import messages
+from django.contrib.messages.storage.base import Message
+from django.template.loader import render_to_string
 from django.urls import reverse
 
 
@@ -19,3 +23,35 @@ def test_dashboard_renders_without_a_player_faction(logged_in_client, savegame_w
     response = logged_in_client.get(reverse("account:dashboard-view"))
 
     assert response.status_code == 200
+
+
+def test_message_with_a_quote_stays_inside_the_javascript_string_literal():
+    """
+    Deliberate exception to "never assert on rendered HTML" (testing-strategy.md): this defect lives
+    only in the rendered output, so status and context are identical with and without it.
+
+    A message is interpolated into a JavaScript string literal. One holding a double quote used to
+    close that literal early, and a SyntaxError is a parse error - the browser threw away the whole
+    inline block, which is also where the CSRF header, the notification listener and the 5xx toast are
+    registered. Every htmx control on the landing page then posted without a token and got a 403.
+    """
+    content = render_to_string(
+        "base.html", {"messages": [Message(messages.SUCCESS, 'You accepted the quest "Pillage village".')]}
+    )
+
+    assert '"Pillage village"' not in content
+    # the JavaScript escaping of &quot;Pillage village&quot; - a quote that never reaches the literal
+    assert "\\u0026quot\\u003BPillage village\\u0026quot\\u003B" in content
+
+
+def test_message_with_angle_brackets_reaches_the_toast_as_text():
+    """
+    The same exception, for the sink underneath: UIkit inserts "message" as HTML rather than as text,
+    so escaping for the JavaScript literal alone would still let a message be parsed as markup.
+    """
+    content = render_to_string("base.html", {"messages": [Message(messages.SUCCESS, "A raid on <the moor>.")]})
+
+    # < would satisfy the JavaScript parser and still hand UIkit a "<" to open a tag with
+    assert "\\u003Cthe moor" not in content
+    # the JavaScript escaping of &lt;the moor&gt;
+    assert "\\u0026lt\\u003Bthe moor\\u0026gt\\u003B" in content

--- a/apps/common/tests/test_base_template.py
+++ b/apps/common/tests/test_base_template.py
@@ -10,6 +10,7 @@ import pytest
 from django.contrib import messages
 from django.contrib.messages.storage.base import Message
 from django.template.loader import render_to_string
+from django.test import override_settings
 from django.urls import reverse
 
 
@@ -55,3 +56,19 @@ def test_message_with_angle_brackets_reaches_the_toast_as_text():
     assert "\\u003Cthe moor" not in content
     # the JavaScript escaping of &lt;the moor&gt;
     assert "\\u0026lt\\u003Bthe moor\\u0026gt\\u003B" in content
+
+
+@override_settings(MESSAGE_TAGS={messages.SUCCESS: 'success"; alert(1); //'})
+def test_message_level_tag_is_escaped_for_the_javascript_string_literal():
+    """
+    The level tag is interpolated into a second literal on the line below the message, and breaks it
+    the same way. Nothing in this project overrides MESSAGE_TAGS, so the vocabulary is fixed and
+    harmless today - which is exactly why the escaping there would be dropped by someone tidying up
+    without anything failing. It gets "escapejs" and not "escape" because UIkit reads "status" as a
+    CSS class rather than as HTML.
+    """
+    content = render_to_string("base.html", {"messages": [Message(messages.SUCCESS, "A quiet month.")]})
+
+    assert 'status: "success";' not in content
+    # the JavaScript escaping of the quote and both semicolons in the hostile tag above
+    assert 'status: "success\\u0022\\u003B alert(1)\\u003B //",' in content

--- a/docs/patterns/testing-strategy.md
+++ b/docs/patterns/testing-strategy.md
@@ -72,8 +72,14 @@ and assembling context. Keep the tests equally thin — **one test per view**, v
   in a second savegame and assert it is *not* reachable. See [savegame scoping](savegame-scoping.md).
 - The UI is htmx-driven. Where a view sets `HX-Trigger`, assert the header is present — behaviour rides on
   it. Don't assert on the exact JSON payload.
-- **Never assert on rendered HTML.** Status code, context and headers only. Template assertions break on
-  every markup change and catch nothing.
+- **Never assert on rendered HTML**, with one exception. Status code, context and headers only —
+  template assertions break on every markup change and catch nothing. The exception is a defect that
+  exists *only* in the rendered output, which in practice means escaping: a value interpolated into a
+  sink that then mis-parses it. Status and context are identical with the bug present and absent, so
+  nothing else can pin it. Then one test may read the response body, and what it asserts is the
+  escaping, not the markup — the dangerous form is absent and the text still arrived. Name the defect
+  in the docstring and say the rule is being set aside on purpose. This is not licence to assert that a
+  page contains a heading.
 
 ## Don't test
 


### PR DESCRIPTION
## What the story asked for

Accepting a quest landed the player on the town square with every htmx control on it dead — Buy in the
shop, the fyrd draft, Finish month — all posting and being refused, with nothing on screen saying so.

`base.html` interpolated a Django message into a JavaScript string literal with `|safe`, and
`QuestAcceptView.form_valid` builds its message with the quest title wrapped in double quotes. The inner
quote closed the literal early. A `SyntaxError` is a *parse* error, so the browser discarded the whole
inline `<script>` block — which is also where the `htmx:configRequest` CSRF listener, the `notification`
toast listener and the `htmx:beforeOnLoad` 5xx reporter are registered. None of them attached, so every
htmx request went out without `X-CSRFToken` and came back 403. Silently: 403 is not 5xx, and the error
toast's handler was dead too.

Closes #66

## What was built

**`apps/common/templates/base.html`** — the message block now escapes for both sinks it passes through:

```django
message: "{{ message|escape|escapejs }}",
status: "{{ message.level_tag|escapejs }}",
```

`escapejs` is the filter for this position: it escapes the quote, the backslash and the newline that
break the string literal. `escape` is for the sink underneath — `UIkit.notification({message: …})`
inserts its argument as HTML, so without it a `<` in a message would still be parsed as markup. Removing
`|safe` without adding `escape` would have dropped the autoescaping that `|safe` was suppressing, since
`escapejs` returns a value marked safe. `level_tag` is a fixed vocabulary today and no `MESSAGE_TAGS`
override exists in this project, but it sits in the same position, so it is escaped rather than left for
someone to re-derive.

The fix is in the template, not at the call sites: `apps/quest/views.py:55` and
`apps/faction/views.py:185` are deliberately untouched, so the next `messages.add_message` cannot
reintroduce this.

**`docs/patterns/testing-strategy.md`** — "Never assert on rendered HTML" gains one narrow, named
exception, for a defect that exists only in rendered output. This issue is the case the rule as written
had no answer for: status and context are identical with the bug present and absent, so nothing else can
pin it. The exception is scoped to escaping, requires the docstring to name the defect, and says
explicitly that it is not licence to assert a page contains a heading.

**`apps/common/tests/test_base_template.py`** — two regression tests under that exception, one per sink.

## CI

`pre-commit run --all-files` and `uv run pytest --cov` behind the 100% branch gate: both green, first
round. No new Python branches.

The tests were checked against every wrong variant rather than only the right one — they fail against
`{{ message|safe }}`, against `{{ message|escapejs }}` alone and against `{{ message|escape }}` alone,
and pass only against the committed chain.

## Review coverage

Two lenses reviewed `main...HEAD`, both returning complete files: **correctness/message-bus** (no
findings) and **test honesty/coverage substance** (one finding).

**Two lenses were not reviewed.** *Data layer, savegame scoping and migrations* had nothing to look at —
no models, no migrations, no view querysets, no game-balance numbers. *Spec conformance and
simplification* was settled at plan time instead: the issue's own "Direction" section names the fix
almost exactly, and the diff is three files.

The correctness lens rendered the template against a battery of adversarial inputs rather than reasoning
about it — quote, angle brackets, a `</script><script>` breakout attempt, backslash, newline, CR,
backtick, `=`, `;`, U+2028/U+2029, non-ASCII and pre-encoded entities — and confirmed independently that
the filter order is the right way round, and that `escapejs` alone is correct for `level_tag` because
UIkit consumes `status` as a CSS class rather than as HTML.

**The one finding was that the `level_tag|escapejs` half of the fix was pinned by nothing**: reverting
just that filter left the whole test file green. Fixed in `fe2ba8e` with a third test that forces a
hostile tag through `MESSAGE_TAGS` and asserts it cannot close the literal. Verified the same way as the
others — reverting only that half now fails only that test.

## Content review

Walked in a real browser on a throwaway savegame: log in, create a savegame, every nav entry, Finish
month, then the story — accept "Pillage village" and exercise the town square **on the post-accept page
load**, without navigating away first, since navigating away repairs the page and hides all of this.

The three symptoms the issue reported were checked directly:

| Issue reported | Observed |
|---|---|
| console: `Unexpected identifier 'Pillage'` | zero console messages of any kind |
| `typeof NOTIFICATION_TIMEOUT` → `"undefined"` | `"number"`, value `5000` |
| `POST /item/39/buy` → **403 Forbidden** | `POST /item/23/buy` → **200 OK**, swap follows |

Two of the three listeners were seen working on that load: `htmx:configRequest` (the Buy POST carried its
token) and `notification` (Finish month refused while a skirmish was open and its `HX-Trigger` toast
rendered). The 5xx handler was not exercised because nothing returned 5xx — it shares the block with the
two that were confirmed, which either parses or does not.

The toast read `You accepted the quest "Pillage village".` with real double quotes — the check `escape`
alone could have failed, since `&quot;` on screen would mean UIkit's HTML sink was not decoding it.

**No content findings.** One journey step was not walked: the town square on this savegame carries no
fyrd draft control, so there was nothing to click. `pre-commit` and `pytest --cov` re-run green after the
browser phase.
