### PR TITLE
The wage bill only announces itself once it cannot be paid

### DIFF
--- a/apps/account/templates/account/dashboard.html
+++ b/apps/account/templates/account/dashboard.html
@@ -14,6 +14,10 @@
         </div>
     {% endif %}
 
+    {# The page the player lands on after finishing a month, so it is where next month's shortfall is #}
+    {# worth the most: the consequence is three months away and every one of them starts here. #}
+    {% include 'finance/components/wage_bill_warning.html' with show_finance_link=True %}
+
     {% for active_quest in faction.active_quests.all %}
         <div uk-alert>
             <div>

--- a/apps/account/tests/test_views.py
+++ b/apps/account/tests/test_views.py
@@ -6,6 +6,7 @@ from apps.month.tests.factories.player_month_log import PlayerMonthLogFactory
 from apps.quest.tests.factories.quest_contract import QuestContractFactory
 from apps.savegame.models.savegame import Savegame
 from apps.skirmish.tests.factories.skirmish import SkirmishFactory
+from apps.skirmish.tests.factories.warrior import WarriorFactory
 
 
 @pytest.mark.django_db
@@ -109,6 +110,21 @@ def test_dashboard_view_lists_the_month_logs_of_the_current_savegame(logged_in_c
     assert response.status_code == 200
     assert list(response.context["player_month_logs"]) == [player_month_log]
     assert response.context["faction"] == current_savegame.player_faction
+
+
+@pytest.mark.django_db
+def test_dashboard_view_warns_about_a_wage_bill_it_cannot_pay(logged_in_client, current_savegame):
+    """
+    The warning lives in a branch of the template nothing else renders, and it reverses a url and
+    walks two lists inside it - the same shape that answered 500 in the quest case below. A test
+    without a shortfall renders none of it.
+    """
+    WarriorFactory(faction=current_savegame.player_faction, monthly_salary=150, unpaid_months=2)
+
+    response = logged_in_client.get(reverse("account:dashboard-view"))
+
+    assert response.status_code == 200
+    assert response.context["wage_bill_payroll"].is_short is True
 
 
 @pytest.mark.django_db

--- a/apps/common/templates/base.html
+++ b/apps/common/templates/base.html
@@ -66,7 +66,20 @@
             <div class="uk-navbar-item">
                 {# todo: this needs to update itself when we do things with HTMX #}
                 <span >{% include 'common/components/svg_icon.html' with icon_name="warrior_face" size='sm' %} {{ faction_warriors.count }}</span>
-                <span >{% include 'common/components/svg_icon.html' with icon_name="silver" size='sm' %} {{ current_balance }}</span>
+                {# The one element guaranteed to be in front of the player when they click "Finish #}
+                {# month", so it is where the wage bill has to speak up. The detail stays on the #}
+                {# cost card and on the dashboard; this is a marker and a way to reach them. #}
+                {% if wage_bill_payroll.is_short %}
+                    <span class="uk-text-danger">
+                        <a class="uk-text-danger" href="{% url 'finance:transaction-list-view' %}"
+                           title="{{ wage_bill_payroll.missing_amount }} silver short of next month's wages">
+                            {% include 'common/components/svg_icon.html' with icon_name="silver" size='sm' %}
+                            {{ current_balance }} <i class="fa-solid fa-triangle-exclamation"></i>
+                        </a>
+                    </span>
+                {% else %}
+                    <span >{% include 'common/components/svg_icon.html' with icon_name="silver" size='sm' %} {{ current_balance }}</span>
+                {% endif %}
                 <span >{% include 'common/components/svg_icon.html' with icon_name="crossed_swords" size='sm' %} {{ open_skirmishes.count }}</span>
             </div>
         {% endif %}

--- a/apps/faction/handlers/commands/faction.py
+++ b/apps/faction/handlers/commands/faction.py
@@ -32,7 +32,6 @@ from apps.faction.models.faction import Faction
 from apps.item.models import ItemType
 from apps.item.services.generators.item.mercenary import MercenaryItemGenerator
 from apps.skirmish.models.warrior import Warrior
-from apps.town.buildings.hall import Hall
 from apps.town.buildings.marketplace import Marketplace
 from apps.town.buildings.weaponsmith import Weaponsmith
 from apps.town.models import Town
@@ -273,12 +272,8 @@ def handle_set_new_leader_warrior(*, context: SetNewLeaderWarrior) -> list[Event
 
 @message_registry.register_command(command=EarnMoneyFromBuildings)
 def handle_earn_money_from_buildings(*, context: EarnMoneyFromBuildings) -> list[Event] | Event:
-    # Get hall building
-    hall_type = context.faction.town.hall
-    hall_building = Hall.get_building_by_type(building_type=hall_type)
-
     return MonthlyBuildingMoneyEarned(
         faction=context.faction,
-        amount=hall_building.REVENUE_PER_ROUND,
+        amount=context.faction.town.get_monthly_income(),
         month=context.month,
     )

--- a/apps/faction/handlers/commands/warrior.py
+++ b/apps/faction/handlers/commands/warrior.py
@@ -13,6 +13,7 @@ from apps.faction.models.culture import Culture
 from apps.faction.models.faction import Faction
 from apps.finance.models import Transaction
 from apps.skirmish.models import Warrior
+from apps.skirmish.projections.payroll import Payroll
 from apps.town.buildings.hall import Hall
 from apps.warrior.services.generators.warrior.fyrd import FyrdWarriorGenerator
 from apps.warrior.services.generators.warrior.mercenary import MercenaryWarriorGenerator
@@ -97,47 +98,37 @@ def handle_warrior_monthly_salaries(*, context: PayMonthlyWarriorSalaries) -> li
     something and failed to pay something. The paid event stays silent at zero, though, because it
     writes a transaction and a log line, and "salaries of 0 silver paid" directly above "you were
     150 short" reads as a contradiction.
+
+    Who ends up on which side is [Payroll]'s answer rather than this handler's, so the card that
+    warns the player beforehand can ask the same question and get the same men.
     """
-    balance = Transaction.objects.current_balance(faction_id=context.faction.id)
-
-    paid_amount = 0
-    missing_amount = 0
-    paid_warrior_list = []
-    unpaid_warrior_list = []
-
-    for warrior in Warrior.objects.get_payroll_for_faction(faction=context.faction):
-        # No early exit on the first man the purse cannot cover: the payroll is sorted by salary, so
-        # everybody after him costs at least as much and fails the same test anyway, and the loop
-        # collects them all without a second branch to get wrong
-        if paid_amount + warrior.monthly_salary <= balance:
-            paid_amount += warrior.monthly_salary
-            paid_warrior_list.append(warrior)
-        else:
-            missing_amount += warrior.monthly_salary
-            unpaid_warrior_list.append(warrior)
+    payroll = Payroll.for_faction(
+        faction=context.faction,
+        budget=Transaction.objects.current_balance(faction_id=context.faction.id),
+    )
 
     # Two writes for the whole roster rather than two per man: this runs on the synchronous month
     # advance, and #3 is about to multiply it by every rival faction in the savegame
-    Warrior.objects.record_salaries_paid(warrior_list=paid_warrior_list)
-    Warrior.objects.record_salaries_unpaid(warrior_list=unpaid_warrior_list)
+    Warrior.objects.record_salaries_paid(warrior_list=payroll.paid_warrior_list)
+    Warrior.objects.record_salaries_unpaid(warrior_list=payroll.unpaid_warrior_list)
 
     message_list = []
 
-    if paid_amount > 0:
+    if payroll.paid_amount > 0:
         message_list.append(
             MonthlyWarriorSalariesPaid(
                 faction=context.faction,
-                amount=paid_amount,
+                amount=payroll.paid_amount,
                 month=context.month,
             )
         )
 
-    if unpaid_warrior_list:
+    if payroll.is_short:
         message_list.append(
             MonthlyWarriorSalariesUnpaid(
                 faction=context.faction,
-                warrior_list=unpaid_warrior_list,
-                missing_amount=missing_amount,
+                warrior_list=payroll.unpaid_warrior_list,
+                missing_amount=payroll.missing_amount,
                 month=context.month,
             )
         )

--- a/apps/faction/templates/faction/faction/components/current_cost_card.html
+++ b/apps/faction/templates/faction/faction/components/current_cost_card.html
@@ -4,8 +4,22 @@
         <tbody>
         <tr>
             <td>Salaries</td>
-            <td>{{ monthly_salary_amount }}</td>
+            <td>{{ wage_bill_payroll.total_amount }}</td>
         </tr>
+        <tr>
+            <td>
+                Building income
+                <span class="uk-text-meta">arrives after the wages</span>
+            </td>
+            <td>{{ building_income_amount }}</td>
+        </tr>
+        {% if not wage_bill_payroll.is_short %}
+            <tr>
+                <td>Left after next month's wages</td>
+                <td>{{ wage_bill_payroll.remaining_amount }}</td>
+            </tr>
+        {% endif %}
         </tbody>
     </table>
+    {% include 'finance/components/wage_bill_warning.html' %}
 </div>

--- a/apps/faction/tests/test_views.py
+++ b/apps/faction/tests/test_views.py
@@ -12,7 +12,8 @@ from apps.skirmish.models.skirmish import Skirmish
 from apps.skirmish.models.warrior import Warrior
 from apps.skirmish.tests.factories.skirmish import SkirmishFactory
 from apps.skirmish.tests.factories.warrior import WarriorFactory
-from apps.town.buildings.hall import NoHall
+from apps.town.buildings.hall import MediumHall
+from apps.town.models import Town
 
 
 @pytest.fixture
@@ -473,15 +474,20 @@ def test_monthly_cost_overview_sums_up_the_salaries(logged_in_client, current_sa
 @pytest.mark.django_db
 def test_monthly_cost_overview_names_the_income_of_the_hall(logged_in_client, current_savegame):
     """
-    The one number the card assembles itself, because nothing else on any page shows it - and it is
-    read off the building rather than repeated here, the way every balance number is.
+    The one number the card assembles itself, because nothing else on any page shows it - off the
+    town the same way the month reads it. A hall above the baseline, so a card answering with the
+    default income for every town would fail here.
     """
+    town = current_savegame.player_faction.town
+    town.hall = Town.HallChoices.HALL_MEDIUM
+    town.save()
+
     response = logged_in_client.get(
         reverse("faction:faction-monthly-costs-view", kwargs={"pk": current_savegame.player_faction.id})
     )
 
     assert response.status_code == 200
-    assert response.context["building_income_amount"] == NoHall.REVENUE_PER_ROUND
+    assert response.context["building_income_amount"] == MediumHall.REVENUE_PER_ROUND
 
 
 @pytest.mark.django_db

--- a/apps/faction/tests/test_views.py
+++ b/apps/faction/tests/test_views.py
@@ -12,6 +12,7 @@ from apps.skirmish.models.skirmish import Skirmish
 from apps.skirmish.models.warrior import Warrior
 from apps.skirmish.tests.factories.skirmish import SkirmishFactory
 from apps.skirmish.tests.factories.warrior import WarriorFactory
+from apps.town.buildings.hall import NoHall
 
 
 @pytest.fixture
@@ -454,6 +455,10 @@ def test_faction_attack_view_without_an_active_savegame(logged_in_client):
 
 @pytest.mark.django_db
 def test_monthly_cost_overview_sums_up_the_salaries(logged_in_client, current_savegame):
+    """
+    The wage bill is not this view's own any more: it comes off "wage_bill_payroll", the projection
+    the salary run bills from, so the card and the month cannot disagree about the number.
+    """
     WarriorFactory(faction=current_savegame.player_faction, monthly_salary=30)
     WarriorFactory(faction=current_savegame.player_faction, monthly_salary=12)
 
@@ -462,7 +467,21 @@ def test_monthly_cost_overview_sums_up_the_salaries(logged_in_client, current_sa
     )
 
     assert response.status_code == 200
-    assert response.context["monthly_salary_amount"] == 42
+    assert response.context["wage_bill_payroll"].total_amount == 42
+
+
+@pytest.mark.django_db
+def test_monthly_cost_overview_names_the_income_of_the_hall(logged_in_client, current_savegame):
+    """
+    The one number the card assembles itself, because nothing else on any page shows it - and it is
+    read off the building rather than repeated here, the way every balance number is.
+    """
+    response = logged_in_client.get(
+        reverse("faction:faction-monthly-costs-view", kwargs={"pk": current_savegame.player_faction.id})
+    )
+
+    assert response.status_code == 200
+    assert response.context["building_income_amount"] == NoHall.REVENUE_PER_ROUND
 
 
 @pytest.mark.django_db

--- a/apps/faction/views.py
+++ b/apps/faction/views.py
@@ -19,6 +19,7 @@ from apps.savegame.mixins import (
 from apps.savegame.models.savegame import Savegame
 from apps.skirmish.messages.commands.skirmish import AttackFaction
 from apps.skirmish.models.warrior import Warrior
+from apps.town.buildings.hall import Hall
 
 
 class FactionDetailView(SavegameScopedQuerysetMixin, generic.DetailView):
@@ -199,12 +200,14 @@ class MonthlyCostOverview(SavegameScopedQuerysetMixin, generic.DetailView):
         # Fetch current savegame record
         current_savegame: Savegame = Savegame.objects.get_current_savegame(user_id=self.request.user.id)
 
-        # The same sum the salary run bills against, taken from the same place: the card is a
-        # promise about what next month costs, and it used to make that promise with its own copy of
-        # the aggregate
-        context["monthly_salary_amount"] = Warrior.objects.get_monthly_salary_for_faction(
-            faction=current_savegame.player_faction
-        )
+        # The wage bill itself is not assembled here. It comes off "wage_bill_payroll", the same
+        # projection the salary run bills from and the navbar warns from, which the finance context
+        # processor puts on every render - computing it here again is what made the card and the
+        # month disagree about who goes unpaid. Only the income is this card's own, because it is
+        # the one number on it that nothing else shows.
+        hall_building = Hall.get_building_by_type(building_type=current_savegame.player_faction.town.hall)
+        context["building_income_amount"] = hall_building.REVENUE_PER_ROUND
+
         return context
 
 

--- a/apps/faction/views.py
+++ b/apps/faction/views.py
@@ -19,7 +19,6 @@ from apps.savegame.mixins import (
 from apps.savegame.models.savegame import Savegame
 from apps.skirmish.messages.commands.skirmish import AttackFaction
 from apps.skirmish.models.warrior import Warrior
-from apps.town.buildings.hall import Hall
 
 
 class FactionDetailView(SavegameScopedQuerysetMixin, generic.DetailView):
@@ -204,9 +203,9 @@ class MonthlyCostOverview(SavegameScopedQuerysetMixin, generic.DetailView):
         # projection the salary run bills from and the navbar warns from, which the finance context
         # processor puts on every render - computing it here again is what made the card and the
         # month disagree about who goes unpaid. Only the income is this card's own, because it is
-        # the one number on it that nothing else shows.
-        hall_building = Hall.get_building_by_type(building_type=current_savegame.player_faction.town.hall)
-        context["building_income_amount"] = hall_building.REVENUE_PER_ROUND
+        # the one number on it that nothing else shows - and it is read off the town, the same way
+        # the month reads it, rather than assembled from a building here.
+        context["building_income_amount"] = current_savegame.player_faction.town.get_monthly_income()
 
         return context
 

--- a/apps/finance/context_processors.py
+++ b/apps/finance/context_processors.py
@@ -1,5 +1,6 @@
 from apps.finance.models import Transaction
 from apps.savegame.models.savegame import Savegame
+from apps.skirmish.projections.payroll import Payroll
 
 
 def get_current_balance(request) -> dict:  # noqa: PBR001
@@ -14,8 +15,19 @@ def get_current_balance(request) -> dict:  # noqa: PBR001
     # the key out: base.html renders the amount behind a "current_savegame" check only, so a missing
     # key puts a silver coin icon followed by nothing into the navbar.
     if current_savegame is None or current_savegame.player_faction_id is None:
-        return {"current_balance": 0}
+        return {"current_balance": 0, "wage_bill_payroll": None}
 
     current_balance = Transaction.objects.current_balance(faction_id=current_savegame.player_faction_id)
 
-    return {"current_balance": current_balance}
+    # The wage bill rides along with the balance rather than living in a context processor of its
+    # own, because it is the same purse measured against next month's roster: a second processor
+    # would repeat this savegame lookup and this balance query on every authenticated render, and
+    # could answer from a different one of the two. The navbar shows them side by side.
+    #
+    # The budget is today's balance with no income added. Wages are billed before the hall pays out
+    # - "handle_pay_monthly_warrior_salaries_for_new_month" is registered ahead of
+    # "handle_earn_money_from_buildings_for_new_month" on PlayerMonthPrepared and queuebie drains in
+    # order - so this month's income funds next month's wages, not the ones being projected here.
+    wage_bill_payroll = Payroll.for_faction(faction=current_savegame.player_faction, budget=current_balance)
+
+    return {"current_balance": current_balance, "wage_bill_payroll": wage_bill_payroll}

--- a/apps/finance/templates/finance/components/wage_bill_warning.html
+++ b/apps/finance/templates/finance/components/wage_bill_warning.html
@@ -1,0 +1,35 @@
+{# Silent while the wages are covered: the card and the dashboard both include this unconditionally, #}
+{# so a faction in the black gets no alert rather than a green one saying nothing happened. #}
+{% if wage_bill_payroll.is_short %}
+    <div class="uk-alert-danger" uk-alert>
+        <h4 class="uk-margin-remove-bottom">
+            <i class="fa-solid fa-triangle-exclamation"></i>
+            {{ wage_bill_payroll.missing_amount }} silver short of next month's wages
+        </h4>
+        <p class="uk-margin-remove-top uk-text-small">
+            Wages are paid cheapest man first out of the silver you hold when the month turns. Your
+            buildings pay out after them, so that income covers the month after this one.
+        </p>
+        <p class="uk-margin-remove">
+            Going unpaid:
+            {% for warrior in wage_bill_payroll.unpaid_warrior_list %}
+                {{ warrior }} ({{ warrior.monthly_salary }} silver){% if not forloop.last %}, {% endif %}
+            {% endfor %}
+        </p>
+        {% if wage_bill_payroll.deserting_warrior_list %}
+            <p class="uk-margin-remove uk-text-bold">
+                Leaving the war band over it:
+                {% for warrior in wage_bill_payroll.deserting_warrior_list %}
+                    {{ warrior }}{% if not forloop.last %}, {% endif %}
+                {% endfor %}
+                — {{ wage_bill_payroll.months_until_desertion }} months without wages and a man strips his
+                gear and walks.
+            </p>
+        {% endif %}
+        {% if show_finance_link %}
+            <p class="uk-margin-remove-bottom">
+                <a href="{% url 'finance:transaction-list-view' %}">Look at the books</a>
+            </p>
+        {% endif %}
+    </div>
+{% endif %}

--- a/apps/finance/tests/test_context_processors.py
+++ b/apps/finance/tests/test_context_processors.py
@@ -4,6 +4,7 @@ from apps.faction.tests.factories.faction import FactionFactory
 from apps.finance.context_processors import get_current_balance
 from apps.finance.tests.factories.transaction import TransactionFactory
 from apps.savegame.tests.factories.savegame import SavegameFactory
+from apps.skirmish.tests.factories.warrior import WarriorFactory
 
 
 @pytest.mark.django_db
@@ -15,7 +16,7 @@ def test_get_current_balance_sums_up_the_transactions_of_the_player_faction(rf, 
     request = rf.get("/")
     request.user = user
 
-    assert get_current_balance(request) == {"current_balance": 250}
+    assert get_current_balance(request)["current_balance"] == 250
 
 
 @pytest.mark.django_db
@@ -28,20 +29,54 @@ def test_get_current_balance_ignores_the_transactions_of_rival_factions(rf, user
     request = rf.get("/")
     request.user = user
 
-    assert get_current_balance(request) == {"current_balance": 250}
+    assert get_current_balance(request)["current_balance"] == 250
+
+
+@pytest.mark.django_db
+def test_get_current_balance_projects_the_wage_bill_against_the_purse(rf, user):
+    """
+    The projection rides along with the balance because it is measured against it, and the navbar
+    shows the two side by side. Today's silver with no income added: the wages are billed before the
+    hall pays out.
+    """
+    savegame = SavegameFactory(created_by=user)
+    savegame.player_faction = FactionFactory(savegame=savegame)
+    savegame.save()
+    TransactionFactory(faction=savegame.player_faction, amount=100)
+    WarriorFactory(faction=savegame.player_faction, monthly_salary=150)
+    request = rf.get("/")
+    request.user = user
+
+    wage_bill_payroll = get_current_balance(request)["wage_bill_payroll"]
+
+    assert wage_bill_payroll.is_short is True
+    assert wage_bill_payroll.missing_amount == 150
+
+
+@pytest.mark.django_db
+def test_get_current_balance_projects_no_shortfall_while_the_wages_are_covered(rf, user):
+    savegame = SavegameFactory(created_by=user)
+    savegame.player_faction = FactionFactory(savegame=savegame)
+    savegame.save()
+    TransactionFactory(faction=savegame.player_faction, amount=100)
+    WarriorFactory(faction=savegame.player_faction, monthly_salary=40)
+    request = rf.get("/")
+    request.user = user
+
+    assert get_current_balance(request)["wage_bill_payroll"].is_short is False
 
 
 @pytest.mark.django_db
 def test_get_current_balance_without_a_player_faction(rf, savegame_without_player_faction, user):
     """
     The savegame row exists before its faction does, and this runs on every authenticated render, so
-    it has to answer with an empty purse rather than dereference the missing faction. Leaving the key
-    out is not an option: base.html renders the amount behind a "current_savegame" check only.
+    it has to answer with an empty purse rather than dereference the missing faction. Leaving the keys
+    out is not an option: base.html renders both behind a "current_savegame" check only.
     """
     request = rf.get("/")
     request.user = user
 
-    assert get_current_balance(request) == {"current_balance": 0}
+    assert get_current_balance(request) == {"current_balance": 0, "wage_bill_payroll": None}
 
 
 @pytest.mark.django_db
@@ -53,4 +88,4 @@ def test_get_current_balance_without_an_active_savegame(rf, user):
     request = rf.get("/")
     request.user = user
 
-    assert get_current_balance(request) == {"current_balance": 0}
+    assert get_current_balance(request) == {"current_balance": 0, "wage_bill_payroll": None}

--- a/apps/month/tests/test_views.py
+++ b/apps/month/tests/test_views.py
@@ -112,6 +112,29 @@ def test_finish_month_view_keeps_an_unpaid_warriors_morale_down(logged_in_client
 
 
 @pytest.mark.django_db
+def test_finish_month_view_bills_the_wages_before_the_buildings_pay_out(logged_in_client, current_savegame):
+    """
+    Flow test rather than a unit test, because what it pins is the ordering of two commands and
+    nothing but a real queue run has one.
+
+    This warrior costs less than the hall earns, and still goes unpaid: both handlers hang off
+    PlayerMonthPrepared with the salary run registered first, so the payroll reads the purse before
+    the income lands in it. That is what the cost card and the navbar promise the player - a wage
+    bill measured against today's silver, with the income funding the month after - so reversing the
+    two would silently turn every one of those warnings into a false alarm.
+    """
+    # The bulletin board restocks as part of the month and a quest needs somebody to be against
+    FactionFactory(savegame=current_savegame)
+    warrior = WarriorFactory(faction=current_savegame.player_faction, monthly_salary=40)
+
+    response = logged_in_client.post(reverse("month:finish-month-view"))
+
+    assert response.status_code == 200
+    warrior.refresh_from_db()
+    assert warrior.unpaid_months == 1
+
+
+@pytest.mark.django_db
 def test_finish_month_view_refuses_a_finished_savegame(logged_in_client, current_savegame):
     """
     Covers the htmx branch of RunningSavegameRequiredMixin; which views carry it at all is asserted

--- a/apps/savegame/managers/savegame.py
+++ b/apps/savegame/managers/savegame.py
@@ -27,9 +27,14 @@ class SavegameManager(manager.Manager):
     def get_current_savegame(self, *, user_id: int) -> Savegame | None:
         """
         Efficient getter for the users current savegame
+
+        The player faction comes along for the ride because four context processors call this on
+        every authenticated render and three of them go straight on to read it - so leaving it out
+        bought a second query per caller rather than saving anything. It is a nullable one-to-one, so
+        this is a left join and a savegame without a faction still comes back.
         """
         try:
-            return self.get(created_by=user_id, is_active=True)
+            return self.select_related("player_faction").get(created_by=user_id, is_active=True)
         except self.model.DoesNotExist:
             return None
 

--- a/apps/skirmish/managers/warrior.py
+++ b/apps/skirmish/managers/warrior.py
@@ -1,5 +1,5 @@
 from django.db import models
-from django.db.models import Q, Sum, manager
+from django.db.models import Q, manager
 
 
 class WarriorQuerySet(models.QuerySet):
@@ -195,24 +195,15 @@ class WarriorManager(manager.Manager):
 
         return gains
 
-    def get_monthly_salary_for_faction(self, *, faction) -> int:
-        """
-        Calculate the salary of all warriors working for "faction" not being dead.
-        """
-        return (
-            self.exclude(condition=self.model.ConditionChoices.CONDITION_DEAD)
-            .filter(faction=faction)
-            .aggregate(amount=Sum("monthly_salary"))["amount"]
-            or 0
-        )
-
     def get_payroll_for_faction(self, *, faction) -> list:
         """
         Everybody "faction" owes wages to this month, cheapest man first.
 
-        The same roster "get_monthly_salary_for_faction" sums - the dead draw nothing, and a captive
-        is off it already because capture clears his faction - but handed over warrior by warrior,
-        because a faction that cannot pay the whole bill has to know who it did manage to pay.
+        The dead draw nothing, and a captive is off the roster already because capture clears his
+        faction. Handed over warrior by warrior rather than as a sum, because a faction that cannot
+        pay the whole bill has to know who it did manage to pay - and the cost card has to know who
+        it would fail to pay. [Payroll] is what both of them ask; there used to be an aggregate
+        beside this for the card, and the two could answer differently.
 
         The order is the rule: paying from the cheapest up fits the most men into whatever silver
         there is, and leaves the shortfall sitting on the dearest. Those are the veterans, the ones

--- a/apps/skirmish/projections/payroll.py
+++ b/apps/skirmish/projections/payroll.py
@@ -1,0 +1,104 @@
+from dataclasses import dataclass, field
+
+from apps.skirmish.models import Warrior
+
+
+@dataclass(kw_only=True)
+class Payroll:
+    """
+    Who a faction can pay out of the silver it has, and who it would have to leave short.
+
+    Built once and read from two ends, which is the whole point of it existing: the salary run bills
+    from it when the month turns, and the cost card warns from it beforehand. The split used to sit
+    inside "handle_warrior_monthly_salaries", so a warning could only have been a second copy of the
+    rule - and a warning naming a different man than the month takes is worse than none.
+
+    Pure: it is handed a roster and a number and reads nothing itself. "for_faction" is the one place
+    that touches the database.
+    """
+
+    # Cheapest man first, the way "get_payroll_for_faction" hands the roster over. The order is a
+    # rule rather than a detail - it decides which man goes without - so this projection takes it as
+    # given instead of sorting again and getting to disagree.
+    warrior_list: list
+    budget: int
+    # Read for the desertion projection only, because the leader is the one man who never walks.
+    leader_id: int | None
+
+    paid_warrior_list: list = field(init=False, default_factory=list)
+    unpaid_warrior_list: list = field(init=False, default_factory=list)
+
+    def __post_init__(self) -> None:
+        paid_amount = 0
+
+        for warrior in self.warrior_list:
+            # No early exit on the first man the purse cannot cover: the roster is sorted by salary,
+            # so everybody after him costs at least as much and fails the same test anyway, and the
+            # loop collects them all without a second branch to get wrong
+            if paid_amount + warrior.monthly_salary <= self.budget:
+                paid_amount += warrior.monthly_salary
+                self.paid_warrior_list.append(warrior)
+            else:
+                self.unpaid_warrior_list.append(warrior)
+
+    @classmethod
+    def for_faction(cls, *, faction, budget: int) -> Payroll:
+        return cls(
+            warrior_list=Warrior.objects.get_payroll_for_faction(faction=faction),
+            budget=budget,
+            leader_id=faction.leader_id,
+        )
+
+    @property
+    def paid_amount(self) -> int:
+        return sum(warrior.monthly_salary for warrior in self.paid_warrior_list)
+
+    @property
+    def missing_amount(self) -> int:
+        return sum(warrior.monthly_salary for warrior in self.unpaid_warrior_list)
+
+    @property
+    def total_amount(self) -> int:
+        return self.paid_amount + self.missing_amount
+
+    @property
+    def remaining_amount(self) -> int:
+        """
+        What is left of the purse once the wages are out of it.
+
+        Goes negative on a shortfall, which is deliberate rather than clamped: the card only shows
+        this while the wages are covered, and a floor of zero would read as "nothing left" for a
+        faction that is actually in trouble.
+        """
+        return self.budget - self.total_amount
+
+    @property
+    def is_short(self) -> bool:
+        return len(self.unpaid_warrior_list) > 0
+
+    @property
+    def months_until_desertion(self) -> int:
+        """
+        How many unpaid months a man takes before he walks, so a template can say the number without
+        holding a copy of it.
+        """
+        return Warrior.UNPAID_MONTHS_UNTIL_DESERTION
+
+    @property
+    def deserting_warrior_list(self) -> list:
+        """
+        The men a shortfall would cost the faction outright rather than only in morale.
+
+        Counted as "one more than he has gone without already", because that is the state
+        "handle_punish_unpaid_warrior" reads: the salary run has recorded this month's failure by the
+        time it asks. So this is only a projection while nothing has been recorded yet - which is
+        exactly when a warning is worth anything.
+
+        The leader is left out for the reason he is left out there: losing him defeats the faction,
+        so he sulks indefinitely instead of walking, and a warning that he leaves would be a lie.
+        """
+        return [
+            warrior
+            for warrior in self.unpaid_warrior_list
+            if warrior.unpaid_months + 1 >= Warrior.UNPAID_MONTHS_UNTIL_DESERTION and warrior.id != self.leader_id
+        ]

--- a/apps/skirmish/tests/projections/test_payroll.py
+++ b/apps/skirmish/tests/projections/test_payroll.py
@@ -1,0 +1,130 @@
+import pytest
+
+from apps.faction.tests.factories.faction import FactionFactory
+from apps.skirmish.projections.payroll import Payroll
+from apps.skirmish.tests.factories.warrior import WarriorFactory
+
+
+def test_paid_warrior_list_holds_the_whole_roster_when_the_purse_covers_it():
+    payroll = Payroll(
+        warrior_list=[WarriorFactory.build(id=1, monthly_salary=30), WarriorFactory.build(id=2, monthly_salary=40)],
+        budget=100,
+        leader_id=1,
+    )
+
+    assert [warrior.id for warrior in payroll.paid_warrior_list] == [1, 2]
+    assert payroll.unpaid_warrior_list == []
+
+
+def test_paid_warrior_list_stops_where_the_silver_does():
+    """
+    The dearest man is the one left short, because the roster arrives cheapest first - so this is
+    also the assertion that the projection does not sort it again.
+    """
+    payroll = Payroll(
+        warrior_list=[WarriorFactory.build(id=1, monthly_salary=30), WarriorFactory.build(id=2, monthly_salary=40)],
+        budget=50,
+        leader_id=1,
+    )
+
+    assert [warrior.id for warrior in payroll.paid_warrior_list] == [1]
+    assert [warrior.id for warrior in payroll.unpaid_warrior_list] == [2]
+
+
+def test_paid_warrior_list_is_empty_on_an_empty_purse():
+    payroll = Payroll(warrior_list=[WarriorFactory.build(id=1, monthly_salary=30)], budget=0, leader_id=1)
+
+    assert payroll.paid_warrior_list == []
+    assert [warrior.id for warrior in payroll.unpaid_warrior_list] == [1]
+
+
+def test_amounts_split_the_wage_bill():
+    payroll = Payroll(
+        warrior_list=[WarriorFactory.build(id=1, monthly_salary=30), WarriorFactory.build(id=2, monthly_salary=40)],
+        budget=50,
+        leader_id=1,
+    )
+
+    assert (payroll.paid_amount, payroll.missing_amount) == (30, 40)
+    assert payroll.total_amount == 70
+
+
+def test_remaining_amount_is_what_the_purse_keeps():
+    payroll = Payroll(warrior_list=[WarriorFactory.build(id=1, monthly_salary=30)], budget=100, leader_id=1)
+
+    assert payroll.remaining_amount == 70
+
+
+def test_is_short_when_a_warrior_goes_unpaid():
+    payroll = Payroll(warrior_list=[WarriorFactory.build(id=1, monthly_salary=30)], budget=0, leader_id=1)
+
+    assert payroll.is_short is True
+
+
+def test_is_short_stays_false_while_the_wages_are_covered():
+    payroll = Payroll(warrior_list=[WarriorFactory.build(id=1, monthly_salary=30)], budget=30, leader_id=1)
+
+    assert payroll.is_short is False
+
+
+def test_months_until_desertion_names_the_number_the_punishment_reads():
+    payroll = Payroll(warrior_list=[], budget=0, leader_id=1)
+
+    assert payroll.months_until_desertion == 3
+
+
+def test_deserting_warrior_list_names_the_man_on_his_last_month():
+    """
+    Two months already gone without, so the month being projected is the third - which is what
+    handle_punish_unpaid_warrior acts on, since the salary run has recorded the failure by then.
+    """
+    payroll = Payroll(
+        warrior_list=[WarriorFactory.build(id=2, monthly_salary=30, unpaid_months=2)], budget=0, leader_id=1
+    )
+
+    assert [warrior.id for warrior in payroll.deserting_warrior_list] == [2]
+
+
+def test_deserting_warrior_list_leaves_out_a_warrior_with_months_to_go():
+    payroll = Payroll(
+        warrior_list=[WarriorFactory.build(id=2, monthly_salary=30, unpaid_months=1)], budget=0, leader_id=1
+    )
+
+    assert payroll.deserting_warrior_list == []
+
+
+def test_deserting_warrior_list_leaves_out_the_leader():
+    """
+    He never walks over wages - losing him defeats the faction, so he sulks indefinitely - and a
+    warning saying otherwise would promise something the month does not deliver.
+    """
+    payroll = Payroll(
+        warrior_list=[WarriorFactory.build(id=1, monthly_salary=30, unpaid_months=5)], budget=0, leader_id=1
+    )
+
+    assert payroll.deserting_warrior_list == []
+
+
+def test_deserting_warrior_list_ignores_a_warrior_who_is_getting_paid():
+    payroll = Payroll(
+        warrior_list=[WarriorFactory.build(id=2, monthly_salary=30, unpaid_months=2)], budget=30, leader_id=1
+    )
+
+    assert payroll.deserting_warrior_list == []
+
+
+@pytest.mark.django_db
+def test_for_faction_reads_the_roster_and_the_leader_off_the_faction():
+    """
+    The one place this projection touches the database, so it is also the only test here needing it.
+    """
+    faction = FactionFactory()
+    leader = WarriorFactory(faction=faction, monthly_salary=40)
+    faction.leader = leader
+    faction.save()
+    WarriorFactory(faction=faction, monthly_salary=30, unpaid_months=2)
+
+    payroll = Payroll.for_faction(faction=faction, budget=30)
+
+    assert (payroll.paid_amount, payroll.missing_amount) == (30, 40)
+    assert payroll.deserting_warrior_list == []

--- a/apps/town/models/town.py
+++ b/apps/town/models/town.py
@@ -1,5 +1,6 @@
 from django.db import models
 
+from apps.town.buildings.hall import Hall
 from apps.town.managers.town import TownManager
 
 
@@ -65,3 +66,14 @@ class Town(models.Model):
         holding a second copy of them that can drift from the column.
         """
         return dict(self._meta.get_field(building_type).choices)[level]
+
+    def get_monthly_income(self) -> int:
+        """
+        What the town pays out when a month turns.
+
+        The hall is the only building with a recurring payout and it owns the number, so this reads
+        it off the level standing rather than holding a copy. One place for it because the month
+        bills it and the cost card promises it, and a card naming a different figure than the month
+        pays is the kind of thing a player never forgives.
+        """
+        return Hall.get_building_by_type(building_type=self.hall).REVENUE_PER_ROUND

--- a/apps/town/tests/models/test_town.py
+++ b/apps/town/tests/models/test_town.py
@@ -14,3 +14,18 @@ def test_get_building_level_display_names_a_level_that_is_not_the_current_one():
     result = town.get_building_level_display(building_type="hall", level=Town.HallChoices.HALL_MEDIUM)
 
     assert result == "Great Hall"
+
+
+def test_get_monthly_income_pays_the_baseline_of_a_town_without_a_hall():
+    """
+    Level 0 is a baseline rather than nothing, so a hall-less town is the case that has to earn.
+    """
+    town = TownFactory.build(hall=Town.HallChoices.HALL_NONE)
+
+    assert town.get_monthly_income() == 50
+
+
+def test_get_monthly_income_pays_the_revenue_of_the_hall_standing():
+    town = TownFactory.build(hall=Town.HallChoices.HALL_MEDIUM)
+
+    assert town.get_monthly_income() == 550


### PR DESCRIPTION
## What the story asked for

#72: a player should see that next month's wages are more than they can pay **before** the month turns, so
losing a veteran to insolvency is the consequence of a decision rather than news. The issue's open
question — *does this warn, or does it also offer a way out?* — is answered in its comments: **warn only.**
The way out is now #76.

Closes #72

## What is in here

**The selection logic came out of the handler.** `apps/skirmish/projections/payroll.py` holds a pure
`Payroll`: handed a roster cheapest-man-first and a purse, it answers who gets paid, who goes short, by how
much, and *who leaves over it*. `handle_warrior_monthly_salaries` now bills from it instead of its own
inline loop, so the warning and the month cannot name different men. The aggregate that used to sit beside
`get_payroll_for_faction` for the card alone is gone with it.

**The shortfall rides along with the balance**, in the finance context processor, so it is available on
every authenticated render:

- the navbar marks the silver and links to `/finance/` — the one element in front of the player when they
  click *Finish month*
- the dashboard, where the player lands the moment a month turns, carries the detail: the shortfall, the
  men going unpaid with their wages, and separately the men who will walk
- the cost card grows a **Building income** row, a **Left after next month's wages** row while solvent, and
  the same warning while not

**No income term in the threshold, because the game has none.** Both handlers hang off
`PlayerMonthPrepared` with the salary run registered first (`apps/faction/handlers/events/faction.py:50`
before `:55`) and queuebie drains in order, so **the wages are billed before the hall pays out** — this
month's income funds next month's payroll. The issue suggested "balance plus income is less than the wage
bill"; that would have been a false alarm generator. A flow test now pins the ordering, because reversing
those two handlers would quietly turn every warning in this PR into a lie without failing anything else.

## CI

`pre-commit run --all-files` and `uv run pytest --cov` both green, coverage at 100% branch. 616 tests.

## Review coverage

Sharded review at head `1f9e85e`, both launched lenses ran to completion:

- **01 Correctness and message-bus wiring** — complete, no findings. Verified that `Payroll` reproduces the
  old loop exactly, that the `+1` in the desertion projection matches what `handle_punish_unpaid_warrior`
  reads after `record_salaries_unpaid` has incremented, and that reading the amounts after those writes
  cannot diverge.
- **02 Data layer, savegame scoping, migrations** — complete, one finding, **fixed**: reading the payroll
  through `current_savegame.player_faction` added an avoidable faction-row query to every authenticated
  render. Fixed at the root — `get_current_savegame` now selects the player faction, which three of its
  four context-processor callers go straight on to read.
- **03 Test honesty** and **04 Spec conformance** — **not reviewed.** The diff is ~500 changed lines and the
  shard table allots two lenses up to 600, so the two lowest-ranked were dropped.

## Content review

Played in a browser from a fresh savegame through month 5: drafted the fyrd out (bill 150 → 786), built the
Marketplace to drain the purse (balance 400), and watched the warning appear in the navbar, on the
dashboard and in the cost card.

The two things that had to be true were true. The warning said *"442 silver short"* over Maurice and
Jonathan; the month log then said *"442 silver short: 2 warriors went unpaid."* Two months later it named
those two as leaving, and the log reported exactly those two leaving and nobody else. Alex the leader sat
at the same two unpaid months as Jeremy, was listed as going unpaid and never as leaving — the carve-out,
month after month, while Jeremy left on cue.

Zero 4xx, zero 5xx, zero tracebacks, clean console.

## Out of scope, named not fixed

- **The hall paying out after the wages.** This PR tells the truth about it; whether the ordering is what
  #45 meant is its own question and worth an issue.
- **A fyrd levy arriving with 0/0 health** (seen in the smoke savegame at 177 silver a month). Generator
  ground, and #41 collects papercuts like it.
- Anything that lets the player *act* on the warning — #76 (dismissal), #70 (rehiring a deserter).

