### PR TITLE
A drafted levy can arrive with no health at all and die to the first blow

### DIFF
--- a/apps/skirmish/managers/warrior.py
+++ b/apps/skirmish/managers/warrior.py
@@ -179,8 +179,8 @@ class WarriorManager(manager.Manager):
         resets them, so keeping a fractional remainder there would mean a level-up eats a month of
         training and a month of training triggers level-up growth. Levels round per event.
         """
-        # The refresh matters twice over: it takes the authoritative values, and it is also what turns
-        # a generated warrior's float attributes into the integers the arithmetic below assumes
+        # Refreshed so the arithmetic below runs on the authoritative values rather than on whatever
+        # this instance was still holding
         obj.refresh_from_db()
 
         grown_fields = ("strength", "dexterity", "max_health", "max_morale", "monthly_salary")

--- a/apps/skirmish/models/warrior.py
+++ b/apps/skirmish/models/warrior.py
@@ -143,14 +143,8 @@ class Warrior(models.Model):
         Derived rather than stored: a column would need a backfill for every warrior generated with
         experience already, and would then be free to drift out of step with the experience it is
         supposed to describe.
-
-        Coerced to an int because a freshly generated warrior does not hold one. BaseWarriorGenerator
-        rolls "random.gauss" and hands the float straight to "objects.create", and Django does not
-        re-read after a create - so the database has an integer while the in-memory instance still has
-        30.4, and "isqrt(30.4 // 100)" raises. That is every warrior in the pub and every leader on the
-        turn a savegame is created.
         """
-        return isqrt(int(experience) // Warrior.XP_LEVEL_BASE) + 1
+        return isqrt(experience // Warrior.XP_LEVEL_BASE) + 1
 
     @property
     def level(self) -> int:

--- a/apps/skirmish/tests/models/test_warrior.py
+++ b/apps/skirmish/tests/models/test_warrior.py
@@ -40,14 +40,6 @@ def test_level_for_the_second_threshold():
     assert Warrior.level_for(experience=400) == 3
 
 
-def test_level_for_a_float_experience():
-    """
-    A generated warrior holds the float "random.gauss" rolled, because Django does not re-read after a
-    create. "isqrt" refuses one, so the coercion inside is what keeps every warrior in the pub readable.
-    """
-    assert Warrior.level_for(experience=130.7) == 2
-
-
 def test_level_reads_the_warriors_own_experience():
     warrior = WarriorFactory.build(experience=400)
 

--- a/apps/warrior/services/generators/warrior/base.py
+++ b/apps/warrior/services/generators/warrior/base.py
@@ -16,7 +16,6 @@ class BaseWarriorGenerator:
     HEALTH_SIGMA: int
     MORALE_MU: int
     MORALE_SIGMA: int
-    # TODO (#41): ensure that both stats are never zero
     STATS_MU: int
     STATS_SIGMA: int
     STATS_MIN: int
@@ -39,45 +38,50 @@ class BaseWarriorGenerator:
     def process(self) -> Warrior:
         faker = Faker([self.culture.locale])
 
+        # Every roll is rounded to the integer its column holds, and rounded before the guard sees
+        # it. The guards compare against zero, and a raw "random.gauss" float of 0.42 satisfies them
+        # and is then truncated to zero on the way into the column - a warrior with no health at
+        # all, who cannot be wounded because his death threshold is zero, cannot be healed because
+        # the monthly sweep asks for current below maximum, and draws a full wage regardless.
+        # Rounding is what makes the guards real retries, and it keeps the instance handed back in
+        # step with the row written, since Django does not re-read after a create.
         experience = 0
         while experience == 0:
-            experience = max(random.gauss(self.XP_MU, self.XP_SIGMA), 0)
+            experience = max(round(random.gauss(self.XP_MU, self.XP_SIGMA)), 0)
 
         max_health = 0
         while max_health == 0:
-            max_health = max(random.gauss(self.HEALTH_MU, self.HEALTH_SIGMA), 0)
+            max_health = max(round(random.gauss(self.HEALTH_MU, self.HEALTH_SIGMA)), 0)
 
         health_progress = -1
         while health_progress < 0 or health_progress > 100:
-            health_progress = max(random.gauss(self.PROGRESS_MU, self.PROGRESS_SIGMA), 0)
+            health_progress = max(round(random.gauss(self.PROGRESS_MU, self.PROGRESS_SIGMA)), 0)
 
         max_morale = 0
         while max_morale == 0:
-            max_morale = max(random.gauss(self.MORALE_MU, self.MORALE_SIGMA), 0)
+            max_morale = max(round(random.gauss(self.MORALE_MU, self.MORALE_SIGMA)), 0)
 
         morale_progress = -1
         while morale_progress < 0 or morale_progress > 100:
-            morale_progress = max(random.gauss(self.PROGRESS_MU, self.PROGRESS_SIGMA), 0)
+            morale_progress = max(round(random.gauss(self.PROGRESS_MU, self.PROGRESS_SIGMA)), 0)
 
-        strength = 0
-        while strength == 0:
-            strength = max(random.gauss(self.STATS_MU, self.STATS_SIGMA), self.STATS_MIN)
+        # Floored at STATS_MIN rather than guarded and re-rolled: every generator sets a minimum of
+        # at least one, so a stat cannot come out at zero the way health and morale can.
+        strength = max(round(random.gauss(self.STATS_MU, self.STATS_SIGMA)), self.STATS_MIN)
 
         strength_progress = -1
         while strength_progress < 0 or strength_progress > 100:
-            strength_progress = max(random.gauss(self.PROGRESS_MU, self.PROGRESS_SIGMA), 0)
+            strength_progress = max(round(random.gauss(self.PROGRESS_MU, self.PROGRESS_SIGMA)), 0)
 
-        dexterity = 0
-        while dexterity == 0:
-            dexterity = max(random.gauss(self.STATS_MU, self.STATS_SIGMA), self.STATS_MIN)
+        dexterity = max(round(random.gauss(self.STATS_MU, self.STATS_SIGMA)), self.STATS_MIN)
 
         dexterity_progress = -1
         while dexterity_progress < 0 or dexterity_progress > 100:
-            dexterity_progress = max(random.gauss(self.PROGRESS_MU, self.PROGRESS_SIGMA), 0)
+            dexterity_progress = max(round(random.gauss(self.PROGRESS_MU, self.PROGRESS_SIGMA)), 0)
 
         base_recruitment_price = 0
         while base_recruitment_price == 0:
-            base_recruitment_price = max(random.gauss(100, 50), 0)
+            base_recruitment_price = max(round(random.gauss(100, 50)), 0)
         recruitment_price = int(
             (((strength + dexterity) / self.STATS_MU) + (max_health / self.HEALTH_MU)) * base_recruitment_price
         )

--- a/apps/warrior/tests/services/generators/warrior/test_base.py
+++ b/apps/warrior/tests/services/generators/warrior/test_base.py
@@ -6,6 +6,94 @@ from apps.faction.models import Culture
 from apps.savegame.tests.factories.savegame import SavegameFactory
 from apps.skirmish.models.warrior import Warrior
 from apps.warrior.services.generators.warrior.fyrd import FyrdWarriorGenerator
+from apps.warrior.services.generators.warrior.leader import LeaderWarriorGenerator
+
+
+@pytest.mark.django_db
+def test_process_leaves_a_warrior_whose_experience_is_an_integer():
+    """
+    Every roll is rounded, so the instance handed back holds the same integer the row does even
+    though Django does not re-read after a create. "isqrt" refuses a float, and this is every warrior
+    in the pub and every leader on the turn a savegame is created.
+    """
+    generator = FyrdWarriorGenerator(culture=Culture.objects.first(), faction=None, savegame_id=SavegameFactory().id)
+
+    result = generator.process()
+
+    assert isinstance(result.experience, int)
+    assert result.level == Warrior.objects.get(pk=result.pk).level
+
+
+@pytest.mark.django_db
+def test_process_rounds_a_sub_one_health_roll_up_to_a_point():
+    """
+    The band between zero and one is the one a truncating column turns into a warrior with no health
+    at all, so it is patched rather than waited for.
+    """
+    generator = FyrdWarriorGenerator(culture=Culture.objects.first(), faction=None, savegame_id=SavegameFactory().id)
+
+    with mock.patch("apps.warrior.services.generators.warrior.base.random.gauss", return_value=0.6):
+        result = generator.process()
+
+    assert result.max_health == 1
+    assert Warrior.objects.get(pk=result.pk).max_health == 1
+
+
+@pytest.mark.django_db
+def test_process_rounds_a_sub_one_morale_roll_up_to_a_point():
+    generator = FyrdWarriorGenerator(culture=Culture.objects.first(), faction=None, savegame_id=SavegameFactory().id)
+
+    with mock.patch("apps.warrior.services.generators.warrior.base.random.gauss", return_value=0.6):
+        result = generator.process()
+
+    assert result.max_morale == 1
+    assert Warrior.objects.get(pk=result.pk).max_morale == 1
+
+
+@pytest.mark.django_db
+def test_process_rerolls_a_roll_that_rounds_to_zero():
+    """
+    Every roll comes up at minus five first, which the floor and the rounding turn into the zero the
+    guards refuse, and then at twelve. A "return_value" the guards reject would spin for ever, so the
+    second value is what proves the retry fires and the loops terminate.
+    """
+    generator = FyrdWarriorGenerator(culture=Culture.objects.first(), faction=None, savegame_id=SavegameFactory().id)
+
+    with mock.patch("apps.warrior.services.generators.warrior.base.random.gauss", side_effect=[-5, 12] * 10):
+        result = generator.process()
+
+    assert result.max_health == 12
+    assert result.max_morale == 12
+
+
+@pytest.mark.django_db
+def test_process_keeps_a_progress_roll_at_its_ceiling():
+    """
+    A roll just above a hundred rounds down onto the ceiling rather than over it, so the guard takes
+    it instead of asking for another one.
+    """
+    generator = FyrdWarriorGenerator(culture=Culture.objects.first(), faction=None, savegame_id=SavegameFactory().id)
+
+    with mock.patch("apps.warrior.services.generators.warrior.base.random.gauss", return_value=100.4):
+        result = generator.process()
+
+    assert result.health_progress == 100
+    assert result.morale_progress == 100
+
+
+@pytest.mark.django_db
+def test_process_floors_the_stats_at_the_generator_minimum():
+    """
+    A leader sits at STATS_MIN = 4, so a roll that rounds to one is lifted to the minimum instead of
+    being re-rolled - which is why the two stats need no guard.
+    """
+    generator = LeaderWarriorGenerator(culture=Culture.objects.first(), faction=None, savegame_id=SavegameFactory().id)
+
+    with mock.patch("apps.warrior.services.generators.warrior.base.random.gauss", return_value=0.6):
+        result = generator.process()
+
+    assert result.strength == 4
+    assert result.dexterity == 4
 
 
 @pytest.mark.django_db
@@ -34,19 +122,3 @@ def test_process_leaves_the_warrior_bare_when_both_rolls_fail():
 
     assert result.weapon is None
     assert result.armor is None
-
-
-@pytest.mark.django_db
-def test_process_leaves_a_warrior_whose_level_can_be_read():
-    """
-    The generated experience is a float and Django does not re-read after a create, so the instance
-    handed back here keeps it while the database holds an integer. "isqrt" refuses a float, and this
-    is every warrior in the pub and every leader on the turn a savegame is created - so the level is
-    asked of a generated warrior here rather than only of a factory-built one.
-    """
-    generator = FyrdWarriorGenerator(culture=Culture.objects.first(), faction=None, savegame_id=SavegameFactory().id)
-
-    result = generator.process()
-
-    assert isinstance(result.experience, float)
-    assert result.level == Warrior.objects.get(pk=result.pk).level


### PR DESCRIPTION
🤖 Not typed by hand

Closes #78

## What the story asked for

A levy drafted from the fyrd arrived at `0/0` health, read as **Healthy**, and drew 177 silver a month.
`BaseWarriorGenerator.process()` guards every roll with `while value == 0`, but `random.gauss` returns a
float and the columns are integer fields — a roll of `0.42` satisfies the guard and is then truncated to
`0` on the way into the column. The guard rejects an exact `0.0` and nothing else, which is the one band
that was never the problem.

A warrior at `max_health = 0` cannot be wounded, only killed: the death check is
`current_health < max_health * -0.15`, so with a maximum of zero the first point of damage he ever takes
kills him outright and he skips the whole unconscious branch — no prisoner, no ransom, no recovery. Nothing
heals him back over the line either, because the monthly sweep selects on `current_health__lt=F("max_health")`
and `0 < 0` is false.

## What this does

Rounds every roll in `process()` to the integer its column holds, **before** the guard tests it —
`max(round(random.gauss(...)), floor)`. That is the shape the two other gauss call sites already use
(`transaction.py:12`, `training.py:52`) and the item generator alongside them (`item/base.py:47`); the
warrior generator was the one place that omitted it.

Three things fall out of it:

- the `== 0` guards become **real retries**, because an integer `0` is now what they see
- `base_recruitment_price` gets the same treatment, so a `0.42` roll there stops producing a warrior who
  costs 1 silver and draws no wage at all
- the in-memory instance stops holding floats, so `Warrior.level_for`'s `int(experience)` coercion and the
  float half of `apply_level_up_growth`'s refresh comment have nothing left to describe and are gone.
  `test_base.py`'s float assertion is inverted to `int`, which is the fix's own proof.

The two stat re-roll loops are gone as well: `max(round(...), STATS_MIN)` with a minimum of 1, 3 or 4
across the three generators cannot come out at zero, so `while strength == 0` could never fire. A comment
says the floor is what guarantees it, in place of the `TODO (#41)`.

### How often it fired

30 000 rolls per row, comparing what a truncating column does against what this branch does:

| Fyrd roll | zero rate, truncating | zero rate, rounding |
|---|---|---|
| `max_health` (MU 10, SIGMA 10) | 1 in 31 | 0 in 30 000 |
| `max_morale` (MU 5, SIGMA 3) | **1 in 22** | 0 in 30 000 |

Health matches #78's estimate of about one drafted levy in thirty, and **morale is the worse of the two
at 1 in 22** — which lands exactly on the figure #41 entry 8 arrived at from the #45 smoke run. #78 itself
carried no number for the morale half; it identified that guard by reading the code.

### The balance shift, on purpose

Rounding lifts every generated number by ~0.5 on average, so mean fyrd `max_health` moves 12.41 → 12.98,
**+4.6%**. `recruitment_price` is a linear function of those same attributes, so wages rise by roughly the
same proportion — silver per point of quality is unchanged, and an unchanged purse simply buys slightly
fewer, slightly better men. `UNPAID_MORALE_LOSS` is a share of `max_morale`, so the desertion clock does
not move either. Retuning MU/SIGMA to absorb the shift is deliberately not part of this.

## Existing savegames

**A warrior already stored at `0/0` stays broken.** No data migration is proposed, per the issue: the
generator stops producing them, and the ones already in a savegame remain as they are. Saying so rather
than leaving it silent.

## CI

Both gates green — `pre-commit run --all-files` and `uv run pytest --cov` at **620 tests, 100% branch
coverage**.

Six tests carry the fix, all patching `random.gauss` at the boundary. Three of them fail against the
pre-change arithmetic, which is what makes them proof rather than decoration: a `0.6` roll now stores `1`
in the database and on the returned instance for both health and morale, and `experience` is an `int`. The
other three cover the requirements the issue listed separately — the reroll path via
`side_effect=[-5, 12] * 10` (a bare `return_value` the guard rejects would spin for ever), a progress roll
of `100.4` landing on the ceiling rather than over it, and the stats flooring at a leader's `STATS_MIN` of 4.

## Review coverage

Two of four lenses ran, both **complete with zero findings**: **01 correctness and message-bus wiring** and
**03 test honesty and coverage substance**. The diff is 158 changed lines, which the shard table puts at
one lens; the test lens was added on purpose, because the whole risk surface here is whether the new tests
discriminate the fix from the bug.

- **02 data layer, savegame scoping and migrations — not run.** The diff adds no model field, no migration
  and no view, and touches no queryset.
- **04 spec conformance and simplification — not run.** The issue's own "branches that need covering" list
  was checked by lens 03 instead, which found all six present.

## Content review

Walked in a browser on a throwaway savegame: login, savegame creation, the dashboard, all six nav
destinations, all four warrior detail pages, three fyrd drafts and a month turn.

The leader came out at 21/21 health and 12/12 morale with dexterity 5 against a `STATS_MIN` of 4. The three
drafted levies read 14/14, 6/6 and 19/19 health and 3/3, 3/3 and 2/2 morale — **no card reads `0/0`**, every
number an integer, every salary above zero. Finishing the month paid "825 silver" against 176 + 112 + 180 +
357, and the #72 warning then reported the shortfall on the three dearest men. Every htmx POST returned 200;
no console errors, nothing in the server log.

Because a `0/0` levy is a one-in-thirty draft, clicks alone cannot prove its absence, so 900 warriors were
generated through the real generators against the smoke database:

| | fyrd | leader | mercenary |
|---|---|---|---|
| `STATS_MIN` | 1 | 4 | 3 |
| min `max_health` | 1 | 6 | 1 |
| min `max_morale` | 1 | 2 | 1 |
| min `strength` / `dexterity` | 1 / 1 | 4 / 4 | 3 / 3 |
| min `recruitment_price` | 9 | 13 | 20 |
| warriors at 0 health or 0 morale | 0 | 0 | 0 |
| non-integer fields | 0 | 0 | 0 |
| `*_progress` outside `0..100` | 0 | 0 | 0 |

One step came back partial: the pub shows a mercenary's health as a qualitative band ("Low") and its
**Recruit** button is hard-disabled behind a todo in `pub_warrior_card.html:56`, so no numeric mercenary
card is reachable from that screen. That is #36's job, not this story's — the table above covers that
generator instead.

## Out of scope

- **`recruitment_price`'s own `int()`** — an explicit truncation of a derived price, not a column
  truncating a float behind the author's back.
- **Whether `max_health * -0.15` is the right death rule** — only visible here because zero makes it
  degenerate.
- **Retuning MU/SIGMA** for any generator.
- **#53 permanent injuries** — the rule chosen here is the one that stub will have to respect.
- **The disabled pub Recruit button** — that is #36, which names the same template and todo. Not touched.

**Takes over #41 entries 6 and 8.** Both should be ticked off pointing here rather than fixed separately,
since entry 6's conclusion (the stat loops never re-roll) depends on entry 8's.
